### PR TITLE
Fix #22: Allow item pickup while moving 

### DIFF
--- a/src/client/Gameplay/MapleMap/MapDrops.cpp
+++ b/src/client/Gameplay/MapleMap/MapDrops.cpp
@@ -123,13 +123,22 @@ namespace jrc
         for (auto& mmo : drops)
         {
             Optional<const Drop> drop = mmo.second.get();
-            if (drop && drop->bounds().contains(playerpos))
+            if (drop)
             {
-                lootenabled = false;
+                Point<int16_t> droppos = drop->get_position();
+                int dx = droppos.x() - playerpos.x();
+                int dy = droppos.y() - playerpos.y();
 
-                int32_t oid = mmo.first;
-                Point<int16_t> position = drop->get_position();
-                return{ oid, position };
+                const int PICKUP_RADIUS = 25;
+
+                if (dx * dx + dy * dy <= PICKUP_RADIUS * PICKUP_RADIUS)
+                {
+                    lootenabled = false;
+
+                    int32_t oid = mmo.first;
+                    Point<int16_t> position = droppos;
+                    return { oid, position };
+                }
             }
         }
         return{ 0, {} };


### PR DESCRIPTION
Resolves #22

Previously, item pickup required the player position to be strictly inside
the drop bounds rectangle. While moving, the player's position could skip
over the drop bounds between frames, preventing pickup.

This change replaces the strict bounds containment check with a
radius-based distance check around the drop position, allowing
pickup while moving without requiring exact overlap.

Behavior:
- Pickup works while standing.
- Pickup now works while walking.
- No changes to packet dispatch logic.

Close #22 