### PR TITLE
Fix invisible hats

### DIFF
--- a/src/client/Character/Look/CharEquips.cpp
+++ b/src/client/Character/Look/CharEquips.cpp
@@ -111,14 +111,35 @@ namespace jrc
         if (const Clothing* cap = clothes[Equipslot::CAP])
         {
             const std::string& vslot = cap->get_vslot();
-            if (vslot == "CpH1H5")
+            const auto has_marker = [&vslot](const char* marker) {
+                return vslot.find(marker) != std::string::npos;
+            };
+
+            const bool covers_multiple_hair_sections =
+                has_marker("H1") || has_marker("H2") || has_marker("H3") ||
+                has_marker("H4") || has_marker("H6") || has_marker("Hd") ||
+                has_marker("Hf") || has_marker("Hs") || has_marker("Hb") ||
+                has_marker("Hc") || has_marker("Hx");
+            const bool has_h5 = has_marker("H5");
+            const bool fully_covers_face_and_hair = has_marker("Ay") || has_marker("As");
+
+            if (covers_multiple_hair_sections)
+            {
+                if (fully_covers_face_and_hair)
+                    return FULLCOVER;
+
                 return HALFCOVER;
-            else if (vslot == "CpH1H5AyAs")
-                return FULLCOVER;
-            else if (vslot == "CpH5")
+            }
+            else if (has_h5)
+            {
+                // H5-only caps behave like ribbons/headbands in this renderer.
                 return HEADBAND;
+            }
             else
-                return NONE;
+            {
+                // Preserve visibility for unclassified caps without forcing hair to render over them.
+                return HALFCOVER;
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary

Fix hat rendering for character equips by making cap layering depend on the actual vslot hair-coverage markers instead of a tiny set of exact string
matches.

Previously, hats with unrecognized vslot combinations were treated like NONE, so they were not drawn at all. A first-pass fallback made them visible, but
incorrectly rendered some real caps, such as Bronze Koif (1002043, vslot=CpH1H4), as headbands.

This change updates cap classification so:

- multi-section hair coverage markers like H1, H4, H6, Hd, Hf, Hs, Hb, Hc, and Hx render as normal hat layers,
- Ay / As variants still render as full-cover hats,
- H5-only caps continue to use the headband path.

## Why

The old logic only recognized a few exact vslot values:

- CpH1H5
- CpH1H5AyAs
- CpH5

That was too narrow for the actual item data in Character.nx, where many hats use other valid combinations such as CpH1H4. As a result, some hats
disappeared entirely, and others were forced into the wrong layering mode.

## Notes

This PR fixes the specific regression where valid hats were missing or rendered like headbands because of incomplete vslot handling in the character look
system.

Close #34 