### PR TITLE
Fix client freeze when warping into maps with empty background sprite entries

### DIFF
--- a/src/client/Gameplay/MapleMap/MapBackgrounds.cpp
+++ b/src/client/Gameplay/MapleMap/MapBackgrounds.cpp
@@ -56,6 +56,15 @@ namespace jrc
             cy = animation.get_dimensions().y();
         }
 
+        // Some maps use an empty background sprite set to mean "solid black".
+        // Treat those as non-renderable so tiled math never divides by zero.
+        if (cx <= 0 || cy <= 0)
+        {
+            htile = 1;
+            vtile = 1;
+            return;
+        }
+
         htile = 1;
         vtile = 1;
         switch (type)
@@ -95,6 +104,11 @@ namespace jrc
 
     void Background::draw(double viewx, double viewy, float alpha) const
     {
+        if (cx <= 0 || cy <= 0)
+        {
+            return;
+        }
+
         int16_t draw_htile = htile > 1 ? static_cast<int16_t>(Constants::viewwidth() / cx + 3) : 1;
         int16_t draw_vtile = vtile > 1 ? static_cast<int16_t>(Constants::viewheight() / cy + 3) : 1;
 
@@ -173,10 +187,19 @@ namespace jrc
 
     MapBackgrounds::MapBackgrounds(nl::node src)
     {
+        black = src["0"]["bS"].get_string().empty();
+
         int16_t no = 0;
         nl::node back = src[std::to_string(no)];
         while (back.size() > 0)
         {
+            if (back["bS"].get_string().empty())
+            {
+                no++;
+                back = src[std::to_string(no)];
+                continue;
+            }
+
             bool front = back["front"].get_bool();
             if (front)
             {
@@ -190,8 +213,6 @@ namespace jrc
             no++;
             back = src[std::to_string(no)];
         }
-
-        black = src["0"]["bS"].get_string().empty();
     }
 
 


### PR DESCRIPTION
This change fixes a client-side freeze that could happen during map transitions when a destination map contains a back entry with an empty bS value.

The issue showed up when warping to Thieves' Hideout (103000003) through the Thief Statue. That map uses an empty background sprite entry to represent a
black fill layer. The client already recognized the map as black-backed, but it still tried to construct and draw that empty background entry. Because the
entry had no sprite dimensions, the tiled background math could hit zero-dimension calculations and lock up the client during load.

This PR updates the background loader to:

- skip background entries with empty bS
- guard against zero-width or zero-height backgrounds before tiled draw math runs

This preserves the intended black fill behavior while preventing invalid background data from freezing the client.

Why

- fixes the freeze seen after Thief Statue warp
- hardens map loading against malformed or sentinel-style background entries
- keeps the change narrowly scoped to background parsing/rendering

Close #25