### PR TITLE
Fix AP assignment button alignment when no AP is available

### DIFF
--- a/src/client/IO/UITypes/UIStatsInfo.cpp
+++ b/src/client/IO/UITypes/UIStatsInfo.cpp
@@ -242,30 +242,17 @@ namespace jrc
 
     void UIStatsinfo::update_ap()
     {
-        Button::State newstate;
         bool nowap = stats.get_stat(Maplestat::AP) > 0;
-        if (nowap)
-        {
-            newstate = Button::NORMAL;
+        Button::State newstate = nowap ? Button::NORMAL : Button::DISABLED;
 
-            buttons[BT_HP ]->set_position(Point<int16_t>(20, -36));
-            buttons[BT_MP ]->set_position(Point<int16_t>(20, -18));
-            buttons[BT_STR]->set_position(Point<int16_t>(20,  51));
-            buttons[BT_DEX]->set_position(Point<int16_t>(20,  69));
-            buttons[BT_INT]->set_position(Point<int16_t>(20,  87));
-            buttons[BT_LUK]->set_position(Point<int16_t>(20, 105));
-        }
-        else
-        {
-            newstate = Button::DISABLED;
-
-            buttons[BT_HP ]->set_position(Point<int16_t>(-48, 14 ));
-            buttons[BT_MP ]->set_position(Point<int16_t>(-48, 32 ));
-            buttons[BT_STR]->set_position(Point<int16_t>(-48, 101));
-            buttons[BT_DEX]->set_position(Point<int16_t>(-48, 119));
-            buttons[BT_INT]->set_position(Point<int16_t>(-48, 137));
-            buttons[BT_LUK]->set_position(Point<int16_t>(-48, 155));
-        }
+        // Keep the AP controls on a single layout and let the button state
+        // swap the texture. MapleButton already normalizes per-state origins.
+        buttons[BT_HP ]->set_position(Point<int16_t>(20, -36));
+        buttons[BT_MP ]->set_position(Point<int16_t>(20, -18));
+        buttons[BT_STR]->set_position(Point<int16_t>(20,  51));
+        buttons[BT_DEX]->set_position(Point<int16_t>(20,  69));
+        buttons[BT_INT]->set_position(Point<int16_t>(20,  87));
+        buttons[BT_LUK]->set_position(Point<int16_t>(20, 105));
 
         // Beginner AP assignment is controlled by the server: when starter AP
         // is manual, Cosmic exposes spendable AP through the normal stat pool.


### PR DESCRIPTION
## Summary

Fix AP assignment button alignment in the stats window when the character has `0` available AP.

## What Changed

- Kept the AP assignment buttons on a single fixed layout in `UIStatsInfo`
- Switched only the button state between `NORMAL` and `DISABLED`
- Removed the alternate disabled-state positioning that caused the buttons to shift out of alignment

## Why

When AP was available, the buttons were positioned correctly.
When AP reached `0`, the UI moved the disabled buttons to a different set of coordinates, which caused the visible misalignment.

`MapleButton` already handles state-specific texture origin differences, so the buttons do not need separate positions for enabled vs disabled states.

Close #48 