### PR TITLE
Fix false button clicks when dragging mouse while pressed

### DIFF
--- a/src/client/IO/UIDragElement.h
+++ b/src/client/IO/UIDragElement.h
@@ -91,7 +91,9 @@ namespace jrc
                 }
             }
 
-            return { clicked ? Cursor::CLICKING : Cursor::IDLE, false };
+            // Keep click/drag active only when a button or drag area captured
+            // the press. This blocks press-then-hover from triggering controls.
+            return { Cursor::IDLE, false };
         }
 
     protected:

--- a/src/client/IO/UIElement.cpp
+++ b/src/client/IO/UIElement.cpp
@@ -169,7 +169,10 @@ namespace jrc
             }
         }
 
-        return { down ? Cursor::CLICKING : Cursor::IDLE, false };
+        // Do not keep a synthetic "pressed" cursor when no control handled
+        // the current press. Otherwise, dragging onto a button while holding
+        // the mouse can incorrectly fire that button.
+        return { Cursor::IDLE, false };
     }
 
     void UIElement::send_scroll(double)


### PR DESCRIPTION
# PR Description

## Summary
This PR prevents buttons from being triggered when the left mouse button is already held down and the cursor later moves onto a button.

## Root Cause
The UI fallback path returned `Cursor::CLICKING` even when no control handled the press, so hover events during the same hold could be interpreted as a
click.

## Changes
- Updated `src/client/IO/UIElement.cpp`:
  - Fallback cursor result now returns `Cursor::IDLE` when no button handled input.
- Updated `src/client/IO/UIDragElement.h`:
  - Same fallback change to `Cursor::IDLE` unless a drag/button capture actually occurred.

## Behavior Change
- Before: press in non-button area, move onto button while holding -> button could fire.
- After: button only fires when the press is captured by that control.

Close #61 