### PR TITLE
Persist Emscripten cache for Docker WASM builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,9 @@ services:
       dockerfile: docker/builder.Dockerfile
     volumes:
       - .:/app
+      # Persist Emscripten system library cache (zlib/freetype/etc.) between
+      # one-off `docker compose run --rm wasm-builder ...` invocations.
+      - emscripten-cache:/emsdk/upstream/emscripten/cache
     networks:
       - maplestory-network
     profiles: ["tools"]
@@ -68,3 +71,6 @@ services:
 networks:
   maplestory-network:
     external: true
+
+volumes:
+  emscripten-cache:


### PR DESCRIPTION
## Summary

- Added a persistent Docker named volume for the wasm-builder service.
- Mounted emscripten-cache to /emsdk/upstream/emscripten/cache in docker-compose.yml.
- Declared the new emscripten-cache volume in the compose file.

## Problem

Running ./scripts/docker_build_wasm.sh uses docker compose run --rm, which removes the container after each build.
Without a persistent Emscripten cache, ports like zlib and freetype are repeatedly downloaded/compiled on later runs.

## Fix

Persist Emscripten’s cache directory via a Docker named volume so those ports are compiled once and reused in subsequent builds.

Close #28