### PR TITLE
Fix NPC dialogue progression when `END CHAT` is the only usable action

### DIFF
--- a/src/client/IO/UITypes/UINpcTalk.cpp
+++ b/src/client/IO/UITypes/UINpcTalk.cpp
@@ -82,6 +82,7 @@ namespace jrc
         buttons[NO] = std::make_unique<MapleButton>(src["BtNo"]);
 
         active = false;
+        end_confirms_dialogue = false;
     }
 
     void UINpcTalk::draw(float inter) const
@@ -217,7 +218,7 @@ namespace jrc
             }
             break;
         case END:
-            NpcTalkMorePacket(type, 0).dispatch();
+            NpcTalkMorePacket(type, end_confirms_dialogue ? 1 : 0).dispatch();
             active = false;
             break;
         }
@@ -233,6 +234,7 @@ namespace jrc
         selection_labels.clear();
         selected = 0;
         hovered_selection = -1;
+        end_confirms_dialogue = false;
 
         if (msgtype == SELECTION_DIALOGUE_TYPE)
         {
@@ -311,7 +313,12 @@ namespace jrc
             if (has_prev)
                 place_button_from_right(PREV);
             if (!has_prev && !has_next)
+            {
+                // Vanilla sendOk flow: in this case END should also confirm as a
+                // fallback, because some clients/UI skins fail to render BtOK.
+                end_confirms_dialogue = true;
                 place_button_from_right(OK);
+            }
             break;
         }
         case 1:
@@ -330,6 +337,30 @@ namespace jrc
             place_button_from_right(OK);
             break;
         }
+
+        auto has_visible_action_button = [&](Buttons id) {
+            return buttons[id]->is_active() && buttons[id]->width() > 0 && buttons[id]->height() > 0;
+        };
+
+        // If text-only dialogue effectively has no visible action button besides
+        // END, treat END as confirm to avoid trapping the player in mode=0 exits.
+        if (msgtype == 0 &&
+            !has_visible_action_button(OK) &&
+            !has_visible_action_button(NEXT) &&
+            !has_visible_action_button(PREV))
+        {
+            end_confirms_dialogue = true;
+        }
+
+        // Same fallback for accept/decline prompts when YES/NO buttons fail
+        // to render in some WZ/UI variants: END acts as accept so flow advances.
+        if ((msgtype == 1 || msgtype == 12) &&
+            !has_visible_action_button(YES) &&
+            !has_visible_action_button(NO))
+        {
+            end_confirms_dialogue = true;
+        }
+
         type = msgtype;
 
         dimension = { top.width(), static_cast<int16_t>(top.height() + height + bottom.height()) };

--- a/src/client/IO/UITypes/UINpcTalk.h
+++ b/src/client/IO/UITypes/UINpcTalk.h
@@ -78,6 +78,7 @@ namespace jrc
         bool slider;
 
         int8_t type;
+        bool end_confirms_dialogue;
         std::string prompttext;
         std::vector<std::string> selection_texts;
         std::vector<Text> selection_labels;


### PR DESCRIPTION
## Description
This change fixes cases where NPC scripts get stuck because `END CHAT` always sent a cancel response, even when the dialog effectively required a confirm
action.

### Problem
Some dialogs rely on a confirm flow (`OK` / `YES`) to advance script state.
If those action buttons are not effectively available (UI/WZ mismatch), players can only press `END CHAT`, which previously sent `response=0` (cancel) and
terminated progression.

### What changed
- Added `end_confirms_dialogue` state to `UINpcTalk`.
- Updated `END` button behavior:
  - Sends confirm (`response=1`) when fallback is active.
  - Keeps existing cancel behavior otherwise.
- Enabled fallback when:
  - `msgtype=0` and no visible action buttons (`OK/NEXT/PREV`) are usable.
  - `msgtype=1` or `msgtype=12` and no visible `YES/NO` buttons are usable.
  - Vanilla `sendOk` path (no prev/next) to keep progression resilient if `OK` is not renderable.

Close #74 