### PR TITLE
Fix scripted portal progression and harden opcode 206 parsing with one-time diagnostics

### DIFF
--- a/src/client/Gameplay/MapleMap/Portal.cpp
+++ b/src/client/Gameplay/MapleMap/Portal.cpp
@@ -28,7 +28,7 @@ namespace jrc
                    int32_t          tid,
                    std::string      tnm)
         : animation(a), type(t), name(nm), position(p),
-          warpinfo(tid, intramap, tnm, nm)
+          warpinfo(tid, t, intramap, tnm, nm)
     {
         touched = false;
     }

--- a/src/client/Gameplay/MapleMap/Portal.h
+++ b/src/client/Gameplay/MapleMap/Portal.h
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <map>
+#include <utility>
 
 
 namespace jrc
@@ -54,20 +55,32 @@ namespace jrc
 
         struct WarpInfo
         {
+            static constexpr int32_t INVALID_MAP_ID = 999999999;
+
             int32_t mapid;
             std::string toname;
             std::string name;
             bool intramap;
             bool valid;
 
-            WarpInfo(int32_t m, bool i, std::string tn, std::string n)
-                : mapid(m), toname(tn), name(n), intramap(i)
+            bool has_target_map() const
             {
-                valid = mapid < 999999999;
+                return mapid >= 0 && mapid < INVALID_MAP_ID;
+            }
+
+            WarpInfo(int32_t m, Type portal_type, bool i, std::string tn, std::string n)
+                : mapid(m), toname(std::move(tn)), name(std::move(n)), intramap(i), valid(false)
+            {
+                bool scripted = portal_type == SCRIPTED ||
+                    portal_type == SCRIPTED_INVISIBLE ||
+                    portal_type == SCRIPTED_TOUCH ||
+                    portal_type == SCRIPTED_HIDDEN;
+
+                valid = has_target_map() || scripted;
             }
 
             WarpInfo()
-                : WarpInfo(999999999, false, {}, {}) {}
+                : WarpInfo(INVALID_MAP_ID, SPAWN, false, {}, {}) {}
         };
 
         Portal(const Animation* animation,
@@ -98,4 +111,3 @@ namespace jrc
         bool touched;
     };
 }
-

--- a/src/client/Gameplay/Stage.cpp
+++ b/src/client/Gameplay/Stage.cpp
@@ -255,7 +255,10 @@ namespace jrc
         else if (warpinfo.valid)
         {
             ChangeMapPacket(false, -1, warpinfo.name, false).dispatch();
-            player.get_stats().set_mapid(warpinfo.mapid);
+            if (warpinfo.has_target_map())
+            {
+                player.get_stats().set_mapid(warpinfo.mapid);
+            }
             Sound(Sound::PORTAL).play();
         }
     }

--- a/src/client/Net/Handlers/MessagingHandlers.cpp
+++ b/src/client/Net/Handlers/MessagingHandlers.cpp
@@ -1,6 +1,7 @@
 #include "MessagingHandlers.h"
 
 #include "../../Character/Char.h"
+#include "../../Console.h"
 #include "../../Data/ItemData.h"
 #include "../../Gameplay/Stage.h"
 #include "../../IO/UI.h"
@@ -15,6 +16,7 @@
 #include <array>
 #include <cctype>
 #include <climits>
+#include <unordered_set>
 #include <vector>
 
 namespace jrc
@@ -45,6 +47,26 @@ namespace jrc
                 parts.push_back(current);
             }
             return parts;
+        }
+
+        bool can_read_string(InPacket& recv)
+        {
+            if (recv.length() < sizeof(uint16_t))
+            {
+                return false;
+            }
+
+            uint16_t str_length = static_cast<uint16_t>(recv.inspect_short());
+            return recv.length() >= sizeof(uint16_t) + str_length;
+        }
+
+        void log_show_item_gain_once(const std::string& key, const std::string& message)
+        {
+            static std::unordered_set<std::string> logged;
+            if (logged.insert(key).second)
+            {
+                Console::get().print(message);
+            }
         }
 
         std::vector<std::string> token_variants(const std::string& token)
@@ -824,12 +846,39 @@ namespace jrc
 
     void ShowItemGainInChatHandler::handle(InPacket& recv) const
     {
+        if (!recv.available())
+        {
+            log_show_item_gain_once(
+                "empty_payload",
+                "[ShowItemGainInChatHandler] Received empty payload."
+            );
+            return;
+        }
+
         int8_t mode1 = recv.read_byte();
         if (mode1 == 3)
         {
+            if (recv.length() < sizeof(int8_t))
+            {
+                log_show_item_gain_once(
+                    "mode3_missing_subtype",
+                    "[ShowItemGainInChatHandler] Mode 3 payload is missing subtype."
+                );
+                return;
+            }
+
             int8_t mode2 = recv.read_byte();
             if (mode2 == 1) // this actually is 'item gain in chat'
             {
+                if (recv.length() < sizeof(int32_t) * 2)
+                {
+                    log_show_item_gain_once(
+                        "mode3_item_gain_truncated",
+                        "[ShowItemGainInChatHandler] Mode 3 subtype 1 payload is truncated."
+                    );
+                    return;
+                }
+
                 int32_t itemid = recv.read_int();
                 int32_t qty = recv.read_int();
 
@@ -844,30 +893,90 @@ namespace jrc
                 if (auto statusbar = UI::get().get_element<UIStatusbar>())
                     statusbar->send_chatline(message, UIChatbar::BLUE);
             }
+            else
+            {
+                log_show_item_gain_once(
+                    "mode3_unknown_subtype_" + std::to_string(static_cast<int>(mode2)),
+                    "[ShowItemGainInChatHandler] Unhandled mode 3 subtype: " +
+                    std::to_string(static_cast<int>(mode2))
+                );
+            }
+
+            return;
         }
-        else if (mode1 == 13) // card effect
+
+        if (mode1 == 13) // card effect
         {
             Stage::get()
                 .get_player()
                 .show_effect_id(CharEffect::MONSTER_CARD);
+            return;
         }
-        else if (mode1 == 18) // intro effect
+
+        if (mode1 == 18) // intro effect
         {
+            if (!can_read_string(recv))
+            {
+                log_show_item_gain_once(
+                    "mode18_truncated_string",
+                    "[ShowItemGainInChatHandler] Mode 18 payload is missing effect path."
+                );
+                return;
+            }
+
             std::string path = recv.read_string();
             Stage::get().add_effect(path);
             schedule_intro_warp_from_path(path);
+            return;
         }
-        else if (mode1 == 23) // info
+
+        if (mode1 == 23) // info
         {
+            if (!can_read_string(recv))
+            {
+                log_show_item_gain_once(
+                    "mode23_truncated_string",
+                    "[ShowItemGainInChatHandler] Mode 23 payload is missing info path."
+                );
+                return;
+            }
+
             std::string path = recv.read_string();
+
+            if (recv.length() < sizeof(int32_t))
+            {
+                log_show_item_gain_once(
+                    "mode23_missing_parameter",
+                    "[ShowItemGainInChatHandler] Mode 23 payload is missing parameter."
+                );
+                return;
+            }
+
             recv.read_int(); // parameter
             Stage::get().add_effect(path);
+            return;
         }
-        else // buff effect
+
+        log_show_item_gain_once(
+            "mode_fallback_" + std::to_string(static_cast<int>(mode1)),
+            "[ShowItemGainInChatHandler] Treating mode " +
+            std::to_string(static_cast<int>(mode1)) + " as buff effect."
+        );
+
+        if (recv.length() < sizeof(int32_t))
         {
-            int32_t skillid = recv.read_int();
-            // more bytes, but we don't need them
-            Stage::get().get_combat().show_player_buff(skillid);
+            log_show_item_gain_once(
+                "mode_fallback_truncated_" + std::to_string(static_cast<int>(mode1)),
+                "[ShowItemGainInChatHandler] Mode " +
+                std::to_string(static_cast<int>(mode1)) +
+                " payload is too short for buff parsing."
+            );
+            return;
         }
+
+        // buff effect
+        int32_t skillid = recv.read_int();
+        // more bytes, but we don't need them
+        Stage::get().get_combat().show_player_buff(skillid);
     }
 }


### PR DESCRIPTION
### Summary
This PR fixes two client-side progression/stability issues:

1. Scripted portals (`tm=999999999`) were treated as invalid, which could trap players in maps like `970030000` (Exclusive Training Center).
2. `SHOW_ITEM_GAIN_INCHAT` (opcode `206`) could throw packet underflow errors when receiving shorter/variant payloads.

### What Changed

#### 1) Scripted portal handling
- Updated portal warp validity logic to treat scripted portal types as valid even when target map is sentinel (`999999999`).
- Kept explicit target-map detection via `has_target_map()`.
- Avoided writing sentinel values to local player map state during portal use.

Files:
- `src/client/Gameplay/MapleMap/Portal.h`
- `src/client/Gameplay/MapleMap/Portal.cpp`
- `src/client/Gameplay/Stage.cpp`

#### 2) Opcode 206 parser hardening + low-noise logs
- Added defensive length checks before all reads in `ShowItemGainInChatHandler`.
- Added safe string-read precheck helper.
- Added one-time diagnostic logs for malformed/unknown variants (non-spammy; suitable for `master`).

File:
- `src/client/Net/Handlers/MessagingHandlers.cpp`

### Why
- Prevents players from getting stuck on scripted progression maps.
- Prevents `Packet Error: Stack underflow ... Opcode: 206` crashes/noise from malformed or unhandled packet variants.
- Improves observability for future protocol variant debugging without spamming logs.

Relates to #38 
