### PR TITLE
Fix shop equip tooltip stats pre-purchase by reusing shared EquipTooltip logic

### DIFF
--- a/src/client/Data/EquipData.cpp
+++ b/src/client/Data/EquipData.cpp
@@ -124,6 +124,11 @@ namespace jrc
         return defstats[stat];
     }
 
+    uint8_t EquipData::get_slots() const
+    {
+        return slots;
+    }
+
     Equipslot::Id EquipData::get_eqslot() const
     {
         return eqslot;

--- a/src/client/Data/EquipData.h
+++ b/src/client/Data/EquipData.h
@@ -40,6 +40,8 @@ namespace jrc
         int16_t get_reqstat(Maplestat::Id stat) const;
         // Returns a default stat.
         int16_t get_defstat(Equipstat::Id stat) const;
+        // Returns base upgrade slots for this equip.
+        uint8_t get_slots() const;
         // Returns the equip slot.
         Equipslot::Id get_eqslot() const;
         // Returns the category name.

--- a/src/client/IO/Components/EquipTooltip.cpp
+++ b/src/client/IO/Components/EquipTooltip.cpp
@@ -17,6 +17,8 @@
 //////////////////////////////////////////////////////////////////////////////
 #include "EquipTooltip.h"
 
+#include "../../Character/CharStats.h"
+#include "../../Character/Inventory/InventoryType.h"
 #include "../../Gameplay/Stage.h"
 #include "../../Data/EquipData.h"
 #include "../../Data/WeaponData.h"
@@ -88,14 +90,21 @@ namespace jrc
         jobs[true][5]  = itemtt["Equip"]["Job"]["enable"]["5"];
 
         invpos = 0;
+        source_parent = Tooltip::NONE;
+        source_itemid = 0;
     }
 
     void EquipTooltip::set_equip(Parent parent, int16_t ivp)
     {
-        if (ivp == invpos)
+        if (source_parent == parent && source_itemid == 0 && ivp == invpos)
             return;
 
+        source_parent = parent;
+        source_itemid = 0;
         invpos = ivp;
+
+        if (ivp == 0)
+            return;
 
         const Player& player = Stage::get().get_player();
 
@@ -115,15 +124,54 @@ namespace jrc
 
         auto oequip = player.get_inventory().get_equip(invtype, ivp);
         if (!oequip)
+        {
+            invpos = 0;
             return;
+        }
 
         const Equip& equip = *oequip;
+        const EquipData& equipdata = EquipData::get(equip.get_item_id());
+        load(equip, equipdata, player.get_stats());
+    }
 
+    void EquipTooltip::set_item(Parent parent, int32_t itemid)
+    {
+        if (source_parent == parent && source_itemid == itemid && invpos == -1)
+            return;
+
+        source_parent = parent;
+        source_itemid = itemid;
+        invpos = -1;
+
+        if (itemid == 0 || InventoryType::by_item_id(itemid) != InventoryType::EQUIP)
+        {
+            invpos = 0;
+            return;
+        }
+
+        const EquipData& equipdata = EquipData::get(itemid);
+        if (!equipdata)
+        {
+            invpos = 0;
+            return;
+        }
+
+        EnumMap<Equipstat::Id, uint16_t> stats;
+        for (Equipstat::Id es = Equipstat::STR; es <= Equipstat::JUMP; es = static_cast<Equipstat::Id>(es + 1))
+        {
+            int16_t defstat = equipdata.get_defstat(es);
+            stats[es] = defstat > 0 ? static_cast<uint16_t>(defstat) : 0;
+        }
+
+        // Shop preview only has static item data, so we render a synthetic equip with base stats.
+        Equip preview(itemid, 0, "", 0, equipdata.get_slots(), 0, stats, 0, 0, 0);
+        load(preview, equipdata, Stage::get().get_player().get_stats());
+    }
+
+    void EquipTooltip::load(const Equip& equip, const EquipData& equipdata, const CharStats& stats)
+    {
         int32_t item_id = equip.get_item_id();
-
-        const EquipData& equipdata = EquipData::get(item_id);
         const ItemData& itemdata = equipdata.get_itemdata();
-        const CharStats& stats = player.get_stats();
 
         height = 500;
 

--- a/src/client/IO/Components/EquipTooltip.h
+++ b/src/client/IO/Components/EquipTooltip.h
@@ -29,16 +29,24 @@
 
 namespace jrc
 {
+    class CharStats;
+    class EquipData;
+
     class EquipTooltip : public Tooltip
     {
     public:
         EquipTooltip();
 
         void set_equip(Parent parent, int16_t invpos);
+        void set_item(Parent parent, int32_t itemid);
         void draw(Point<int16_t> position) const override;
 
     private:
+        void load(const Equip& equip, const EquipData& equipdata, const CharStats& stats);
+
         int16_t invpos;
+        Parent source_parent;
+        int32_t source_itemid;
         int16_t height;
         bool hasdesc;
         bool hasslots;

--- a/src/client/IO/UIStateGame.cpp
+++ b/src/client/IO/UIStateGame.cpp
@@ -33,6 +33,7 @@
 #include "UITypes/UIWorldMap.h"
 
 #include "../Constants.h"
+#include "../Character/Inventory/InventoryType.h"
 #include "../Gameplay/Stage.h"
 
 #include <algorithm>
@@ -451,6 +452,18 @@ namespace jrc
 
     void UIStateGame::show_item(Tooltip::Parent parent, int32_t itemid)
     {
+        if (parent == Tooltip::SHOP && InventoryType::by_item_id(itemid) == InventoryType::EQUIP)
+        {
+            eqtooltip.set_item(parent, itemid);
+
+            if (itemid)
+            {
+                tooltip       = eqtooltip;
+                tooltipparent = parent;
+            }
+            return;
+        }
+
         ittooltip.set_item(itemid);
 
         if (itemid)


### PR DESCRIPTION
## Summary

Shop buy-list equip items were shown with ItemTooltip (name/desc only), so clothing/equip stats were missing until after purchase.

## What changed

- Routed shop equip item hover (show_item in shop context) to EquipTooltip instead of ItemTooltip.
- Refactored EquipTooltip to use one shared load(...) path for:

1. Real inventory equips (set_equip)
2. Shop equip previews (set_item)

- Added EquipData::get_slots() so preview equips can be constructed with correct base upgrade slots.
- Kept non-equip shop items on the existing ItemTooltip path.

## Behavior

- Before: no equip stats while browsing shop buy list.
- After: equip requirements/stats/category/speed are shown during shop hover, before buying.