### PR TITLE
add STORAGE (opcode 309) trunk support

### DIFF
--- a/src/client/IO/UIElement.h
+++ b/src/client/IO/UIElement.h
@@ -66,6 +66,7 @@ namespace jrc
             NOTICE,
             NPCTALK,
             SHOP,
+            STORAGE,
             STATSINFO,
             ITEMINVENTORY,
             EQUIPINVENTORY,

--- a/src/client/IO/UIStateGame.cpp
+++ b/src/client/IO/UIStateGame.cpp
@@ -23,6 +23,7 @@
 #include "UITypes/UIBuffList.h"
 #include "UITypes/UINpcTalk.h"
 #include "UITypes/UIShop.h"
+#include "UITypes/UIStorage.h"
 #include "UITypes/UIStatsInfo.h"
 #include "UITypes/UIItemInventory.h"
 #include "UITypes/UIEquipInventory.h"
@@ -54,6 +55,8 @@ namespace jrc
                 return Tooltip::SKILLBOOK;
             case UIElement::SHOP:
                 return Tooltip::SHOP;
+            case UIElement::STORAGE:
+                return Tooltip::SHOP;
             case UIElement::MINIMAP:
                 return Tooltip::MINIMAP;
             case UIElement::WORLDMAP:
@@ -82,6 +85,7 @@ namespace jrc
         emplace<UIBuffList>();
         emplace<UINpcTalk>();
         emplace<UIShop>(look, inventory);
+        emplace<UIStorage>(inventory);
     }
 
     void UIStateGame::draw(float inter, Point<int16_t> cursor) const

--- a/src/client/IO/UITypes/UIStorage.cpp
+++ b/src/client/IO/UITypes/UIStorage.cpp
@@ -1,0 +1,686 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of the Journey MMORPG client                           //
+// Copyright © 2015-2016 Daniel Allendorf                                   //
+//                                                                          //
+// This program is free software: you can redistribute it and/or modify     //
+// it under the terms of the GNU Affero General Public License as           //
+// published by the Free Software Foundation, either version 3 of the       //
+// License, or (at your option) any later version.                          //
+//                                                                          //
+// This program is distributed in the hope that it will be useful,          //
+// but WITHOUT ANY WARRANTY; without even the implied warranty of           //
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            //
+// GNU Affero General Public License for more details.                      //
+//                                                                          //
+// You should have received a copy of the GNU Affero General Public License //
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.    //
+//////////////////////////////////////////////////////////////////////////////
+#include "UIStorage.h"
+#include "UINotice.h"
+
+#include "../UI.h"
+#include "../Components/AreaButton.h"
+#include "../Components/Charset.h"
+#include "../Components/MapleButton.h"
+#include "../Components/TwoSpriteButton.h"
+
+#include "../../Character/Inventory/InventoryType.h"
+#include "../../Data/ItemData.h"
+#include "../../Net/Packets/NpcInteractionPackets.h"
+#include "../../Util/Misc.h"
+
+#include "nlnx/nx.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+
+namespace jrc
+{
+    namespace
+    {
+        constexpr int16_t ROWS_VISIBLE = 5;
+        constexpr int16_t ROW_TOP = 94;
+        constexpr int16_t ROW_STEP = 42;
+        constexpr int16_t LEFT_ROW_X = 8;
+        constexpr int16_t RIGHT_ROW_X = 177;
+        constexpr int16_t ROW_WIDTH = 160;
+        constexpr int16_t ROW_HEIGHT = 36;
+        constexpr int16_t LEFT_ICON_X = 17;
+        constexpr int16_t RIGHT_ICON_X = 186;
+        constexpr int16_t ICON_Y = 99;
+
+        constexpr InventoryType::Id INVENTORY_TABS[] = {
+            InventoryType::EQUIP,
+            InventoryType::USE,
+            InventoryType::ETC,
+            InventoryType::SETUP,
+            InventoryType::CASH
+        };
+
+        int16_t max_offset(size_t size)
+        {
+            if (size <= ROWS_VISIBLE)
+            {
+                return 0;
+            }
+
+            return static_cast<int16_t>(size - ROWS_VISIBLE);
+        }
+    }
+
+    UIStorage::UIStorage(const Inventory& in_inventory)
+        : inventory(in_inventory),
+          tab(InventoryType::EQUIP),
+          storage_offset(0),
+          inventory_offset(0),
+          storage_selection(-1),
+          inventory_selection(-1),
+          last_cursor_pos(),
+          storage_meso(0),
+          slots(0),
+          npcid(0)
+    {
+        nl::node src = nl::nx::ui["UIWindow2.img"]["Trunk"];
+
+        sprites.emplace_back(src["backgrnd"]);
+        sprites.emplace_back(src["backgrnd2"]);
+        sprites.emplace_back(src["backgrnd3"]);
+
+        buttons[GET] = std::make_unique<MapleButton>(src["BtGet"]);
+        buttons[PUT] = std::make_unique<MapleButton>(src["BtPut"]);
+        buttons[SORT] = std::make_unique<MapleButton>(src["BtSort"]);
+        buttons[IN_COIN] = std::make_unique<MapleButton>(src["BtInCoin"]);
+        buttons[OUT_COIN] = std::make_unique<MapleButton>(src["BtOutCoin"]);
+        buttons[EXIT] = std::make_unique<MapleButton>(src["BtExit"]);
+        buttons[FULL] = std::make_unique<MapleButton>(src["BtFull"]);
+        buttons[SMALL] = std::make_unique<MapleButton>(src["BtSmall"]);
+        buttons[SLOT_EX] = std::make_unique<MapleButton>(src["BtSlotEx"]);
+
+        // Full/Small mode and slot expansion require extra UI flows that are not
+        // implemented yet; keep controls hidden to avoid dead-end interactions.
+        buttons[FULL]->set_active(false);
+        buttons[SMALL]->set_active(false);
+        buttons[SLOT_EX]->set_active(false);
+
+        nl::node tab_enabled = src["Tab"]["enabled"];
+        nl::node tab_disabled = src["Tab"]["disabled"];
+
+        buttons[TAB_EQUIP] = std::make_unique<TwoSpriteButton>(tab_disabled["0"], tab_enabled["0"]);
+        buttons[TAB_USE] = std::make_unique<TwoSpriteButton>(tab_disabled["1"], tab_enabled["1"]);
+        buttons[TAB_ETC] = std::make_unique<TwoSpriteButton>(tab_disabled["2"], tab_enabled["2"]);
+        buttons[TAB_SETUP] = std::make_unique<TwoSpriteButton>(tab_disabled["3"], tab_enabled["3"]);
+        buttons[TAB_CASH] = std::make_unique<TwoSpriteButton>(tab_disabled["4"], tab_enabled["4"]);
+
+        for (int16_t i = 0; i < ROWS_VISIBLE; ++i)
+        {
+            buttons[STORAGE_ROW0 + i] = std::make_unique<AreaButton>(
+                Point<int16_t>(LEFT_ROW_X, ROW_TOP + i * ROW_STEP),
+                Point<int16_t>(ROW_WIDTH, ROW_HEIGHT)
+            );
+
+            buttons[INVENTORY_ROW0 + i] = std::make_unique<AreaButton>(
+                Point<int16_t>(RIGHT_ROW_X, ROW_TOP + i * ROW_STEP),
+                Point<int16_t>(ROW_WIDTH, ROW_HEIGHT)
+            );
+        }
+
+        buttons[button_by_tab(tab)]->set_state(Button::PRESSED);
+
+        selection = nl::nx::ui["UIWindow2.img"]["Shop"]["select"];
+        disabled_slot = src["disabled"];
+        meso_icon = nl::nx::ui["UIWindow2.img"]["Shop"]["meso"];
+
+        storage_mesolabel = { Text::A11M, Text::RIGHT, Text::LIGHTGREY };
+        player_mesolabel = { Text::A11M, Text::RIGHT, Text::LIGHTGREY };
+
+        for (auto type : INVENTORY_TABS)
+        {
+            storage_items[type].clear();
+        }
+
+        refresh_inventory_tab();
+
+        dimension = Texture(src["backgrnd"]).get_dimensions();
+        position = { 400 - dimension.x() / 2, 240 - dimension.y() / 2 };
+        active = false;
+    }
+
+    void UIStorage::draw(float alpha) const
+    {
+        UIElement::draw(alpha);
+
+        static const Charset countset = { nl::nx::ui["Basic.img"]["ItemNo"], Charset::LEFT };
+
+        const auto& current_storage = storage_items[tab];
+        for (int16_t i = 0; i < ROWS_VISIBLE; ++i)
+        {
+            int16_t storage_index = i + storage_offset;
+            Point<int16_t> storage_rowpos = position + Point<int16_t>(LEFT_ROW_X, ROW_TOP + i * ROW_STEP);
+            Point<int16_t> storage_iconpos = position + Point<int16_t>(LEFT_ICON_X, ICON_Y + i * ROW_STEP);
+
+            if (storage_index == storage_selection)
+            {
+                selection.draw(storage_rowpos);
+            }
+
+            if (storage_index >= 0 && storage_index < static_cast<int16_t>(current_storage.size()))
+            {
+                const ItemEntry& entry = current_storage[storage_index];
+                const Texture& icon = ItemData::get(entry.itemid).get_icon(false);
+                icon.draw(storage_iconpos);
+
+                if (tab != InventoryType::EQUIP && entry.count > 1)
+                {
+                    countset.draw(std::to_string(entry.count), storage_iconpos + Point<int16_t>(0, 20));
+                }
+            }
+            else
+            {
+                disabled_slot.draw(storage_iconpos);
+            }
+
+            int16_t inventory_index = i + inventory_offset;
+            Point<int16_t> inventory_rowpos = position + Point<int16_t>(RIGHT_ROW_X, ROW_TOP + i * ROW_STEP);
+            Point<int16_t> inventory_iconpos = position + Point<int16_t>(RIGHT_ICON_X, ICON_Y + i * ROW_STEP);
+
+            if (inventory_index == inventory_selection)
+            {
+                selection.draw(inventory_rowpos);
+            }
+
+            if (inventory_index >= 0 && inventory_index < static_cast<int16_t>(inventory_items.size()))
+            {
+                const InventoryEntry& entry = inventory_items[inventory_index];
+                const Texture& icon = ItemData::get(entry.itemid).get_icon(false);
+                icon.draw(inventory_iconpos);
+
+                if (tab != InventoryType::EQUIP && entry.count > 1)
+                {
+                    countset.draw(std::to_string(entry.count), inventory_iconpos + Point<int16_t>(0, 20));
+                }
+            }
+            else
+            {
+                disabled_slot.draw(inventory_iconpos);
+            }
+        }
+
+        meso_icon.draw(position + Point<int16_t>(142, 317));
+        meso_icon.draw(position + Point<int16_t>(314, 317));
+        storage_mesolabel.draw(position + Point<int16_t>(173, 319));
+        player_mesolabel.draw(position + Point<int16_t>(345, 319));
+    }
+
+    void UIStorage::update()
+    {
+        int64_t player_meso = inventory.get_meso();
+
+        std::string storage_mesostr = std::to_string(storage_meso);
+        std::string player_mesostr = std::to_string(player_meso);
+        string_format::split_number(storage_mesostr);
+        string_format::split_number(player_mesostr);
+
+        storage_mesolabel.change_text(storage_mesostr);
+        player_mesolabel.change_text(player_mesostr);
+    }
+
+    bool UIStorage::remove_cursor(bool clicked, Point<int16_t> cursorpos)
+    {
+        return UIElement::remove_cursor(clicked, cursorpos);
+    }
+
+    UIElement::CursorResult UIStorage::send_cursor(bool clicked, Point<int16_t> cursorpos)
+    {
+        Point<int16_t> cursoroffset = cursorpos - position;
+        last_cursor_pos = cursoroffset;
+
+        int16_t row = slot_by_position(cursoroffset.y());
+        if (row >= 0)
+        {
+            if (cursoroffset.x() >= LEFT_ROW_X && cursoroffset.x() <= LEFT_ROW_X + ROW_WIDTH)
+            {
+                show_item(row, true);
+            }
+            else if (cursoroffset.x() >= RIGHT_ROW_X && cursoroffset.x() <= RIGHT_ROW_X + ROW_WIDTH)
+            {
+                show_item(row, false);
+            }
+            else
+            {
+                clear_tooltip();
+            }
+        }
+        else
+        {
+            clear_tooltip();
+        }
+
+        return UIElement::send_cursor(clicked, cursorpos);
+    }
+
+    void UIStorage::send_scroll(double yoffset)
+    {
+        int16_t yoff = last_cursor_pos.y();
+        int16_t row = slot_by_position(yoff);
+        if (row < 0)
+        {
+            return;
+        }
+
+        int16_t shift = yoffset > 0 ? -1 : 1;
+        int16_t xoff = last_cursor_pos.x();
+
+        if (xoff >= LEFT_ROW_X && xoff <= LEFT_ROW_X + ROW_WIDTH)
+        {
+            storage_offset = static_cast<int16_t>(storage_offset + shift);
+        }
+        else if (xoff >= RIGHT_ROW_X && xoff <= RIGHT_ROW_X + ROW_WIDTH)
+        {
+            inventory_offset = static_cast<int16_t>(inventory_offset + shift);
+        }
+
+        clamp_offsets();
+    }
+
+    void UIStorage::rightclick(Point<int16_t> cursorpos)
+    {
+        Point<int16_t> cursoroffset = cursorpos - position;
+        int16_t row = slot_by_position(cursoroffset.y());
+        if (row < 0)
+        {
+            return;
+        }
+
+        if (cursoroffset.x() >= LEFT_ROW_X && cursoroffset.x() <= LEFT_ROW_X + ROW_WIDTH)
+        {
+            int16_t index = row + storage_offset;
+            if (index >= 0 && index < static_cast<int16_t>(storage_items[tab].size()))
+            {
+                storage_selection = index;
+                inventory_selection = -1;
+                request_take_selected();
+            }
+        }
+        else if (cursoroffset.x() >= RIGHT_ROW_X && cursoroffset.x() <= RIGHT_ROW_X + ROW_WIDTH)
+        {
+            int16_t index = row + inventory_offset;
+            if (index >= 0 && index < static_cast<int16_t>(inventory_items.size()))
+            {
+                inventory_selection = index;
+                storage_selection = -1;
+                request_store_selected();
+            }
+        }
+    }
+
+    void UIStorage::send_key(int32_t, bool pressed, bool escape)
+    {
+        if (pressed && escape)
+        {
+            close_with_packet();
+        }
+    }
+
+    void UIStorage::open(int32_t new_npcid, uint8_t new_slots, int32_t meso)
+    {
+        npcid = new_npcid;
+        slots = new_slots;
+        storage_meso = meso;
+
+        storage_offset = 0;
+        inventory_offset = 0;
+        storage_selection = -1;
+        inventory_selection = -1;
+
+        for (auto type : INVENTORY_TABS)
+        {
+            storage_items[type].clear();
+        }
+
+        refresh_inventory_tab();
+        active = true;
+    }
+
+    void UIStorage::close()
+    {
+        clear_tooltip();
+        active = false;
+        storage_selection = -1;
+        inventory_selection = -1;
+    }
+
+    void UIStorage::set_items_for_all(const EnumMap<InventoryType::Id, std::vector<ItemEntry>>& items)
+    {
+        for (auto type : INVENTORY_TABS)
+        {
+            storage_items[type] = items[type];
+        }
+
+        clamp_offsets();
+    }
+
+    void UIStorage::set_items_for_tab(InventoryType::Id type, const std::vector<ItemEntry>& items)
+    {
+        storage_items[type] = items;
+        clamp_offsets();
+    }
+
+    void UIStorage::set_slots(uint8_t value)
+    {
+        slots = value;
+    }
+
+    void UIStorage::set_meso(int32_t meso)
+    {
+        storage_meso = meso;
+    }
+
+    void UIStorage::modify(InventoryType::Id type)
+    {
+        if (type == tab)
+        {
+            refresh_inventory_tab();
+        }
+    }
+
+    Button::State UIStorage::button_pressed(uint16_t buttonid)
+    {
+        clear_tooltip();
+
+        if (buttonid >= STORAGE_ROW0 && buttonid <= STORAGE_ROW4)
+        {
+            int16_t visible_slot = static_cast<int16_t>(buttonid - STORAGE_ROW0);
+            int16_t slot = static_cast<int16_t>(visible_slot + storage_offset);
+            if (slot >= 0 && slot < static_cast<int16_t>(storage_items[tab].size()))
+            {
+                if (slot == storage_selection)
+                {
+                    request_take_selected();
+                }
+                else
+                {
+                    storage_selection = slot;
+                    inventory_selection = -1;
+                }
+            }
+            return Button::NORMAL;
+        }
+
+        if (buttonid >= INVENTORY_ROW0 && buttonid <= INVENTORY_ROW4)
+        {
+            int16_t visible_slot = static_cast<int16_t>(buttonid - INVENTORY_ROW0);
+            int16_t slot = static_cast<int16_t>(visible_slot + inventory_offset);
+            if (slot >= 0 && slot < static_cast<int16_t>(inventory_items.size()))
+            {
+                if (slot == inventory_selection)
+                {
+                    request_store_selected();
+                }
+                else
+                {
+                    inventory_selection = slot;
+                    storage_selection = -1;
+                }
+            }
+            return Button::NORMAL;
+        }
+
+        switch (buttonid)
+        {
+        case GET:
+            request_take_selected();
+            return Button::NORMAL;
+        case PUT:
+            request_store_selected();
+            return Button::NORMAL;
+        case SORT:
+            request_sort();
+            return Button::NORMAL;
+        case IN_COIN:
+            request_meso_change(true);
+            return Button::NORMAL;
+        case OUT_COIN:
+            request_meso_change(false);
+            return Button::NORMAL;
+        case EXIT:
+            close_with_packet();
+            return Button::PRESSED;
+        case TAB_EQUIP:
+            change_tab(InventoryType::EQUIP);
+            return Button::IDENTITY;
+        case TAB_USE:
+            change_tab(InventoryType::USE);
+            return Button::IDENTITY;
+        case TAB_ETC:
+            change_tab(InventoryType::ETC);
+            return Button::IDENTITY;
+        case TAB_SETUP:
+            change_tab(InventoryType::SETUP);
+            return Button::IDENTITY;
+        case TAB_CASH:
+            change_tab(InventoryType::CASH);
+            return Button::IDENTITY;
+        default:
+            return Button::PRESSED;
+        }
+    }
+
+    void UIStorage::clear_tooltip()
+    {
+        UI::get().clear_tooltip(Tooltip::SHOP);
+    }
+
+    void UIStorage::show_item(int16_t visible_slot, bool storage_side)
+    {
+        int16_t index = static_cast<int16_t>(visible_slot + (storage_side ? storage_offset : inventory_offset));
+
+        if (storage_side)
+        {
+            const auto& items = storage_items[tab];
+            if (index < 0 || index >= static_cast<int16_t>(items.size()))
+            {
+                clear_tooltip();
+                return;
+            }
+
+            UI::get().show_item(Tooltip::SHOP, items[index].itemid);
+            return;
+        }
+
+        if (index < 0 || index >= static_cast<int16_t>(inventory_items.size()))
+        {
+            clear_tooltip();
+            return;
+        }
+
+        UI::get().show_item(Tooltip::SHOP, inventory_items[index].itemid);
+    }
+
+    void UIStorage::refresh_inventory_tab()
+    {
+        inventory_items.clear();
+
+        int16_t slotmax = inventory.get_slotmax(tab);
+        for (int16_t slot = 1; slot <= slotmax; ++slot)
+        {
+            int32_t itemid = inventory.get_item_id(tab, slot);
+            if (itemid == 0)
+            {
+                continue;
+            }
+
+            int16_t count = tab == InventoryType::EQUIP ?
+                1 :
+                inventory.get_item_count(tab, slot);
+
+            inventory_items.push_back({ itemid, count, slot });
+        }
+
+        clamp_offsets();
+    }
+
+    void UIStorage::clamp_offsets()
+    {
+        const auto& storage_tab_items = storage_items[tab];
+
+        storage_offset = std::clamp<int16_t>(storage_offset, 0, max_offset(storage_tab_items.size()));
+        inventory_offset = std::clamp<int16_t>(inventory_offset, 0, max_offset(inventory_items.size()));
+
+        if (storage_selection >= static_cast<int16_t>(storage_tab_items.size()))
+        {
+            storage_selection = -1;
+        }
+
+        if (inventory_selection >= static_cast<int16_t>(inventory_items.size()))
+        {
+            inventory_selection = -1;
+        }
+    }
+
+    void UIStorage::change_tab(InventoryType::Id type)
+    {
+        uint16_t oldtab = button_by_tab(tab);
+        uint16_t newtab = button_by_tab(type);
+
+        buttons[oldtab]->set_state(Button::NORMAL);
+        buttons[newtab]->set_state(Button::PRESSED);
+
+        tab = type;
+        storage_offset = 0;
+        inventory_offset = 0;
+        storage_selection = -1;
+        inventory_selection = -1;
+
+        refresh_inventory_tab();
+    }
+
+    void UIStorage::request_take_selected()
+    {
+        const auto& items = storage_items[tab];
+        if (storage_selection < 0 || storage_selection >= static_cast<int16_t>(items.size()))
+        {
+            return;
+        }
+
+        StorageActionPacket(tab, static_cast<uint8_t>(storage_selection)).dispatch();
+    }
+
+    void UIStorage::request_store_selected()
+    {
+        if (inventory_selection < 0 || inventory_selection >= static_cast<int16_t>(inventory_items.size()))
+        {
+            return;
+        }
+
+        const InventoryEntry entry = inventory_items[inventory_selection];
+        int16_t max_quantity = std::max<int16_t>(1, entry.count);
+
+        if (tab != InventoryType::EQUIP && max_quantity > 1)
+        {
+            auto on_enter = [entry](int32_t quantity) {
+                StorageActionPacket(
+                    entry.slot,
+                    entry.itemid,
+                    static_cast<int16_t>(quantity)
+                ).dispatch();
+            };
+            UI::get().emplace<UIEnterNumber>(
+                "How many would you like to store?",
+                on_enter,
+                1,
+                max_quantity,
+                1
+            );
+            return;
+        }
+
+        StorageActionPacket(entry.slot, entry.itemid, 1).dispatch();
+    }
+
+    void UIStorage::request_sort()
+    {
+        StorageActionPacket::sort().dispatch();
+    }
+
+    void UIStorage::request_meso_change(bool store_to_storage)
+    {
+        int32_t max_value = 0;
+        if (store_to_storage)
+        {
+            int64_t player_meso = inventory.get_meso();
+            int64_t capped = std::min<int64_t>(player_meso, std::numeric_limits<int32_t>::max());
+            max_value = static_cast<int32_t>(std::max<int64_t>(0, capped));
+        }
+        else
+        {
+            max_value = std::max<int32_t>(0, storage_meso);
+        }
+
+        if (max_value <= 0)
+        {
+            return;
+        }
+
+        auto on_enter = [store_to_storage](int32_t amount) {
+            int32_t signed_amount = store_to_storage ? -amount : amount;
+            StorageActionPacket(signed_amount).dispatch();
+        };
+
+        UI::get().emplace<UIEnterNumber>(
+            store_to_storage ? "How many mesos would you like to store?" : "How many mesos would you like to take out?",
+            on_enter,
+            1,
+            max_value,
+            1
+        );
+    }
+
+    void UIStorage::close_with_packet()
+    {
+        close();
+        StorageActionPacket::leave().dispatch();
+    }
+
+    int16_t UIStorage::slot_by_position(int16_t y) const
+    {
+        int16_t yoff = static_cast<int16_t>(y - ROW_TOP);
+        if (yoff < 0)
+        {
+            return -1;
+        }
+
+        int16_t slot = static_cast<int16_t>(yoff / ROW_STEP);
+        if (slot < 0 || slot >= ROWS_VISIBLE)
+        {
+            return -1;
+        }
+
+        int16_t row_start = static_cast<int16_t>(slot * ROW_STEP);
+        if (yoff - row_start >= ROW_HEIGHT)
+        {
+            return -1;
+        }
+
+        return slot;
+    }
+
+    uint16_t UIStorage::button_by_tab(InventoryType::Id type) const
+    {
+        switch (type)
+        {
+        case InventoryType::EQUIP:
+            return TAB_EQUIP;
+        case InventoryType::USE:
+            return TAB_USE;
+        case InventoryType::ETC:
+            return TAB_ETC;
+        case InventoryType::SETUP:
+            return TAB_SETUP;
+        case InventoryType::CASH:
+            return TAB_CASH;
+        default:
+            return TAB_EQUIP;
+        }
+    }
+}

--- a/src/client/IO/UITypes/UIStorage.h
+++ b/src/client/IO/UITypes/UIStorage.h
@@ -1,0 +1,133 @@
+//////////////////////////////////////////////////////////////////////////////
+// This file is part of the Journey MMORPG client                           //
+// Copyright © 2015-2016 Daniel Allendorf                                   //
+//                                                                          //
+// This program is free software: you can redistribute it and/or modify     //
+// it under the terms of the GNU Affero General Public License as           //
+// published by the Free Software Foundation, either version 3 of the       //
+// License, or (at your option) any later version.                          //
+//                                                                          //
+// This program is distributed in the hope that it will be useful,          //
+// but WITHOUT ANY WARRANTY; without even the implied warranty of           //
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            //
+// GNU Affero General Public License for more details.                      //
+//                                                                          //
+// You should have received a copy of the GNU Affero General Public License //
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.    //
+//////////////////////////////////////////////////////////////////////////////
+#pragma once
+#include "../UIElement.h"
+
+#include "../../Character/Inventory/Inventory.h"
+#include "../../Character/Inventory/InventoryType.h"
+#include "../../Graphics/Text.h"
+#include "../../Graphics/Texture.h"
+#include "../../Template/EnumMap.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace jrc
+{
+    class UIStorage : public UIElement
+    {
+    public:
+        struct ItemEntry
+        {
+            int32_t itemid = 0;
+            int16_t count = 0;
+        };
+
+        static constexpr Type TYPE = STORAGE;
+        static constexpr bool FOCUSED = true;
+        static constexpr bool TOGGLED = true;
+
+        explicit UIStorage(const Inventory& inventory);
+
+        void draw(float alpha) const override;
+        void update() override;
+
+        bool remove_cursor(bool clicked, Point<int16_t> cursorpos) override;
+        CursorResult send_cursor(bool clicked, Point<int16_t> cursorpos) override;
+        void send_scroll(double yoffset) override;
+        void rightclick(Point<int16_t> cursorpos) override;
+        void send_key(int32_t keycode, bool pressed, bool escape) override;
+
+        void open(int32_t npcid, uint8_t slots, int32_t meso);
+        void close();
+        void set_items_for_all(const EnumMap<InventoryType::Id, std::vector<ItemEntry>>& items);
+        void set_items_for_tab(InventoryType::Id type, const std::vector<ItemEntry>& items);
+        void set_slots(uint8_t value);
+        void set_meso(int32_t meso);
+        void modify(InventoryType::Id type);
+
+    protected:
+        Button::State button_pressed(uint16_t buttonid) override;
+
+    private:
+        struct InventoryEntry
+        {
+            int32_t itemid = 0;
+            int16_t count = 0;
+            int16_t slot = 0;
+        };
+
+        void clear_tooltip();
+        void show_item(int16_t visible_slot, bool storage_side);
+        void refresh_inventory_tab();
+        void clamp_offsets();
+        void change_tab(InventoryType::Id type);
+
+        void request_take_selected();
+        void request_store_selected();
+        void request_sort();
+        void request_meso_change(bool store_to_storage);
+        void close_with_packet();
+
+        int16_t slot_by_position(int16_t y) const;
+        uint16_t button_by_tab(InventoryType::Id type) const;
+
+        const Inventory& inventory;
+        EnumMap<InventoryType::Id, std::vector<ItemEntry>> storage_items;
+        std::vector<InventoryEntry> inventory_items;
+
+        Texture selection;
+        Texture disabled_slot;
+        Texture meso_icon;
+        Text storage_mesolabel;
+        Text player_mesolabel;
+
+        InventoryType::Id tab;
+        int16_t storage_offset;
+        int16_t inventory_offset;
+        int16_t storage_selection;
+        int16_t inventory_selection;
+        Point<int16_t> last_cursor_pos;
+
+        int32_t storage_meso;
+        uint8_t slots;
+        int32_t npcid;
+
+        enum Buttons : int16_t
+        {
+            GET = 0,
+            PUT = 1,
+            SORT = 2,
+            IN_COIN = 3,
+            OUT_COIN = 4,
+            EXIT = 5,
+            FULL = 6,
+            SMALL = 7,
+            SLOT_EX = 8,
+            TAB_EQUIP = 9,
+            TAB_USE = 10,
+            TAB_ETC = 11,
+            TAB_SETUP = 12,
+            TAB_CASH = 13,
+            STORAGE_ROW0 = 14,
+            STORAGE_ROW4 = 18,
+            INVENTORY_ROW0 = 19,
+            INVENTORY_ROW4 = 23
+        };
+    };
+}

--- a/src/client/Net/Handlers/InventoryHandlers.cpp
+++ b/src/client/Net/Handlers/InventoryHandlers.cpp
@@ -24,6 +24,7 @@
 #include "../../IO/UI.h"
 #include "../../IO/Messages.h"
 #include "../../IO/UITypes/UIShop.h"
+#include "../../IO/UITypes/UIStorage.h"
 #include "../../IO/UITypes/UIEquipInventory.h"
 #include "../../IO/UITypes/UIItemInventory.h"
 
@@ -118,6 +119,10 @@ namespace jrc
             if (auto shop = UI::get().get_element<UIShop>())
             {
                 shop->modify(mod.type);
+            }
+            if (auto storage = UI::get().get_element<UIStorage>())
+            {
+                storage->modify(mod.type);
             }
 
             auto eqinvent = UI::get().get_element<UIEquipInventory>();

--- a/src/client/Net/Handlers/NpcInteractionHandlers.cpp
+++ b/src/client/Net/Handlers/NpcInteractionHandlers.cpp
@@ -19,10 +19,148 @@
 
 #include "../../IO/UI.h"
 #include "../../IO/UITypes/UINpcTalk.h"
+#include "../../IO/UITypes/UINotice.h"
 #include "../../IO/UITypes/UIShop.h"
+#include "../../IO/UITypes/UIStorage.h"
+
+#include <vector>
 
 namespace jrc
 {
+    namespace
+    {
+        using ItemListByType = EnumMap<InventoryType::Id, std::vector<UIStorage::ItemEntry>>;
+
+        InventoryType::Id type_by_storage_bitfield(int16_t bitfield)
+        {
+            switch (bitfield)
+            {
+            case 4:
+                return InventoryType::EQUIP;
+            case 8:
+                return InventoryType::USE;
+            case 16:
+                return InventoryType::SETUP;
+            case 32:
+                return InventoryType::ETC;
+            case 64:
+                return InventoryType::CASH;
+            default:
+                return InventoryType::NONE;
+            }
+        }
+
+        UIStorage::ItemEntry parse_storage_item(InPacket& recv, InventoryType::Id forced_type, InventoryType::Id& parsed_type)
+        {
+            int8_t item_type = recv.read_byte();
+            int32_t item_id = recv.read_int();
+
+            parsed_type = forced_type;
+            if (parsed_type == InventoryType::NONE)
+            {
+                parsed_type = InventoryType::by_item_id(item_id);
+            }
+
+            bool is_cash = recv.read_bool();
+            if (is_cash)
+            {
+                recv.skip(8); // cash id / ring id / pet id
+            }
+
+            recv.skip(8); // expiration
+
+            UIStorage::ItemEntry entry = { item_id, 1 };
+
+            bool is_equip = parsed_type == InventoryType::EQUIP || item_type == 1;
+            bool is_pet = item_id >= 5000000 && item_id <= 5000102;
+
+            if (is_equip)
+            {
+                recv.skip(2); // upgrade slots + level
+                recv.skip(28); // stats
+                recv.read_string(); // owner
+                recv.skip(2); // flags
+
+                if (is_cash)
+                {
+                    recv.skip(10);
+                }
+                else
+                {
+                    recv.skip(18);
+                }
+
+                recv.skip(12); // potential expiration + serial
+            }
+            else if (is_pet)
+            {
+                recv.read_padded_string(13); // name
+                recv.skip(4); // level + closeness + fullness
+                recv.skip(18); // pet details tail
+            }
+            else
+            {
+                entry.count = recv.read_short();
+                recv.read_string(); // owner
+                recv.skip(2); // flags
+
+                bool rechargeable = item_id / 10000 == 207 || item_id / 10000 == 233;
+                if (rechargeable)
+                {
+                    recv.skip(8);
+                }
+            }
+
+            return entry;
+        }
+
+        ItemListByType parse_storage_items(InPacket& recv, uint8_t count, InventoryType::Id forced_type)
+        {
+            ItemListByType parsed = {};
+
+            for (size_t i = 0; i < count; ++i)
+            {
+                InventoryType::Id parsed_type = InventoryType::NONE;
+                UIStorage::ItemEntry entry = parse_storage_item(recv, forced_type, parsed_type);
+                if (parsed_type != InventoryType::NONE)
+                {
+                    parsed[parsed_type].push_back(entry);
+                }
+            }
+
+            return parsed;
+        }
+
+        void show_storage_error_message(int8_t mode)
+        {
+            const char* message = nullptr;
+            switch (mode)
+            {
+            case 0x0A:
+                message = "Your inventory is full.";
+                break;
+            case 0x0B:
+                message = "You do not have enough mesos.";
+                break;
+            case 0x0C:
+                message = "This item cannot be moved from storage.";
+                break;
+            case 0x11:
+                message = "Storage is full.";
+                break;
+            default:
+                break;
+            }
+
+            if (!message)
+            {
+                return;
+            }
+
+            UI::get().emplace<UIOk>(message, []() {});
+        }
+    }
+
     void NpcDialogueHandler::handle(InPacket& recv) const
     {
         recv.skip(1);
@@ -83,5 +221,103 @@ namespace jrc
                 shop.add_rechargable(itemid, price, pitch, time, rechargeprice, slotmax);
             }
         }
+    }
+
+    void StorageHandler::handle(InPacket& recv) const
+    {
+        auto storage = UI::get().get_element<UIStorage>();
+        if (!storage)
+        {
+            return;
+        }
+
+        int8_t mode = recv.read_byte();
+
+        switch (mode)
+        {
+        case 0x16:
+            {
+                int32_t npcid = recv.read_int();
+                uint8_t slots = static_cast<uint8_t>(recv.read_byte());
+
+                recv.skip(2); // inventory mask
+                recv.skip(2); // zero
+                recv.skip(4); // zero
+                int32_t meso = recv.read_int();
+                recv.skip(2); // zero
+
+                uint8_t count = static_cast<uint8_t>(recv.read_byte());
+                ItemListByType items = parse_storage_items(recv, count, InventoryType::NONE);
+
+                if (recv.length() >= 2)
+                {
+                    recv.skip(2);
+                }
+                if (recv.length() >= 1)
+                {
+                    recv.skip(1);
+                }
+
+                storage->open(npcid, slots, meso);
+                storage->set_items_for_all(items);
+            }
+            break;
+        case 0x09:
+        case 0x0D:
+            {
+                uint8_t slots = static_cast<uint8_t>(recv.read_byte());
+                int16_t type_bitfield = recv.read_short();
+                InventoryType::Id type = type_by_storage_bitfield(type_bitfield);
+
+                recv.skip(2); // zero
+                recv.skip(4); // zero
+
+                uint8_t count = static_cast<uint8_t>(recv.read_byte());
+                ItemListByType parsed = parse_storage_items(recv, count, type);
+
+                storage->set_slots(slots);
+                if (type != InventoryType::NONE)
+                {
+                    storage->set_items_for_tab(type, parsed[type]);
+                }
+            }
+            break;
+        case 0x0F:
+            {
+                uint8_t slots = static_cast<uint8_t>(recv.read_byte());
+
+                recv.skip(1);  // 0x7C mask
+                recv.skip(10); // zeroes
+
+                uint8_t count = static_cast<uint8_t>(recv.read_byte());
+                ItemListByType items = parse_storage_items(recv, count, InventoryType::NONE);
+                if (recv.length() >= 1)
+                {
+                    recv.skip(1);
+                }
+
+                storage->set_slots(slots);
+                storage->set_items_for_all(items);
+            }
+            break;
+        case 0x13:
+            {
+                uint8_t slots = static_cast<uint8_t>(recv.read_byte());
+
+                recv.skip(2); // type mask
+                recv.skip(2); // zero
+                recv.skip(4); // zero
+
+                int32_t meso = recv.read_int();
+                storage->set_slots(slots);
+                storage->set_meso(meso);
+            }
+            break;
+        default:
+            show_storage_error_message(mode);
+            break;
+        }
+
+        UI::get().enable();
     }
 }

--- a/src/client/Net/Handlers/NpcInteractionHandlers.h
+++ b/src/client/Net/Handlers/NpcInteractionHandlers.h
@@ -31,4 +31,10 @@ namespace jrc
     {
         void handle(InPacket& recv) const override;
     };
+
+    // Handles storage (trunk) open/update packets.
+    class StorageHandler : public PacketHandler
+    {
+        void handle(InPacket& recv) const override;
+    };
 }

--- a/src/client/Net/OutPacket.h
+++ b/src/client/Net/OutPacket.h
@@ -99,6 +99,7 @@ namespace jrc
         TALK_TO_NPC     = 58,
         NPC_TALK_MORE   = 60,
         NPC_SHOP_ACTION = 61,
+        STORAGE_ACTION  = 62,
 
         // Inventory
         GATHER_ITEMS = 69,

--- a/src/client/Net/PacketSwitch.cpp
+++ b/src/client/Net/PacketSwitch.cpp
@@ -145,6 +145,7 @@ namespace jrc
         // NPC Interaction
         NPC_DIALOGUE  = 304,
         OPEN_NPC_SHOP = 305,
+        STORAGE       = 309,
 
         KEYMAP      = 335,
         AUTO_HP_POT = 336,
@@ -222,6 +223,7 @@ namespace jrc
         // Npc Interaction Handlers
         emplace<NPC_DIALOGUE, NpcDialogueHandler>();
         emplace<OPEN_NPC_SHOP, OpenNpcShopHandler>();
+        emplace<STORAGE, StorageHandler>();
 
         // TODO
         emplace<MOVE_MOB_RESPONSE, NullHandler>();

--- a/src/client/Net/Packets/NpcInteractionPackets.h
+++ b/src/client/Net/Packets/NpcInteractionPackets.h
@@ -18,6 +18,8 @@
 #pragma once
 #include "../OutPacket.h"
 
+#include "../../Character/Inventory/InventoryType.h"
+
 namespace jrc
 {
     // Packet which requests a dialogue with a server-sided npc.
@@ -86,6 +88,64 @@ namespace jrc
         };
 
         NpcShopActionPacket(Mode mode) : OutPacket(NPC_SHOP_ACTION)
+        {
+            write_byte(mode);
+        }
+    };
+
+    // Packet which tells the server of an interaction with storage (trunk).
+    // Opcode: STORAGE_ACTION(62)
+    class StorageActionPacket : public OutPacket
+    {
+    public:
+        // Requests taking out a storage item from the current tab.
+        StorageActionPacket(InventoryType::Id type, uint8_t slot)
+            : StorageActionPacket(TAKE_OUT)
+        {
+            write_byte(static_cast<int8_t>(type));
+            write_byte(static_cast<int8_t>(slot));
+        }
+
+        // Requests storing an inventory item in storage.
+        StorageActionPacket(int16_t slot, int32_t itemid, int16_t qty)
+            : StorageActionPacket(STORE)
+        {
+            write_short(slot);
+            write_int(itemid);
+            write_short(qty);
+        }
+
+        // Requests moving mesos between inventory and storage.
+        // Positive amount withdraws from storage, negative stores mesos.
+        explicit StorageActionPacket(int32_t amount)
+            : StorageActionPacket(MESO)
+        {
+            write_int(amount);
+        }
+
+        // Requests sorting storage items.
+        static StorageActionPacket sort()
+        {
+            return StorageActionPacket(SORT);
+        }
+
+        // Requests exiting storage.
+        static StorageActionPacket leave()
+        {
+            return StorageActionPacket(EXIT);
+        }
+
+    private:
+        enum Mode : int8_t
+        {
+            TAKE_OUT = 4,
+            STORE = 5,
+            SORT = 6,
+            MESO = 7,
+            EXIT = 8
+        };
+
+        explicit StorageActionPacket(Mode mode) : OutPacket(STORAGE_ACTION)
         {
             write_byte(mode);
         }


### PR DESCRIPTION
## Summary
- Add client-side handling for inbound `STORAGE` packets (`opcode 309`) in `PacketSwitch`.
- Implement `StorageHandler` for trunk open/update flows (`0x16`, `0x09`, `0x0D`, `0x0F`, `0x13`) and storage error modes.
- Add outbound `StorageActionPacket` (`opcode 62`) for take out, store, sort, meso transfer, and exit.
- Add new `UIStorage` and wire it into game UI state.
- Keep storage UI in sync when inventory changes.
- Fix storage inventory bitfield decoding to match Cosmic (`4/8/16/32/64`).
- Client-only change (no server behavior changes).

## Notes
- `BtFull`, `BtSmall`, and `BtSlotEx` are intentionally disabled until their extra client flows are implemented.