### PR TITLE
Fix minimum damage range calculation

### DIFF
--- a/src/client/Character/CharStats.cpp
+++ b/src/client/Character/CharStats.cpp
@@ -52,7 +52,8 @@ namespace jrc
         honor = 0;
         attackspeed = 0;
         projectilerange = 400;
-        mastery = 0.0f;
+        // Unmastered attacks still retain a small lower bound instead of dropping to the secondary stat alone.
+        mastery = 0.1f;
         critical = 0.05f;
         mincrit = 0.5f;
         maxcrit = 0.75f;
@@ -99,6 +100,12 @@ namespace jrc
 
     int32_t CharStats::get_secondary_stat() const
     {
+        // Cosmic treats claw users and thief daggers as a mixed secondary stat.
+        if (job.get_id() / 100 == 4 && (weapontype == Weapon::CLAW || weapontype == Weapon::DAGGER))
+        {
+            return get_total(Equipstat::DEX) + get_total(Equipstat::STR);
+        }
+
         Equipstat::Id secondary = job.get_secondary(weapontype);
         return get_total(secondary);
     }
@@ -194,7 +201,7 @@ namespace jrc
 
     void CharStats::set_mastery(float m)
     {
-        mastery = 0.5f + m;
+        mastery = m;
     }
 
     void CharStats::set_damagepercent(float d)

--- a/src/client/Character/PassiveBuffs.cpp
+++ b/src/client/Character/PassiveBuffs.cpp
@@ -62,7 +62,9 @@ namespace jrc
     template <Weapon::Type...W>
     void WeaponMasteryBuff<W...>::apply_to(CharStats& stats, nl::node level) const
     {
-        float mastery = static_cast<float>(level["mastery"]) / 100;
+        // WZ stores mastery in 5% steps above the 10% unmastered floor:
+        // e.g. 1 -> 15%, 10 -> 60%.
+        float mastery = 0.1f + static_cast<float>(level["mastery"]) * 0.05f;
         stats.set_mastery(mastery);
         stats.add_value(Equipstat::ACC, level["x"]);
     }
@@ -105,7 +107,7 @@ namespace jrc
         buffs[SkillId::ACHILLES_HERO] = std::make_unique<AchillesBuff>();
 
         // Page
-        buffs[SkillId::SWORD_MASTERY_FIGHTER] = std::make_unique<WeaponMasteryBuff<Weapon::SWORD_1H, Weapon::SWORD_2H>>();
+        buffs[SkillId::SWORD_MASTERY_PAGE] = std::make_unique<WeaponMasteryBuff<Weapon::SWORD_1H, Weapon::SWORD_2H>>();
         buffs[SkillId::BW_MASTERY] = std::make_unique<WeaponMasteryBuff<Weapon::MACE_1H, Weapon::MACE_2H>>();
 
         // White Knight
@@ -122,6 +124,28 @@ namespace jrc
         // Dark Knight
         buffs[SkillId::ACHILLES_DK] = std::make_unique<AchillesBuff>();
         buffs[SkillId::BERSERK] = std::make_unique<BerserkBuff>();
+
+        // Hunter
+        buffs[SkillId::BOW_MASTERY] = std::make_unique<WeaponMasteryBuff<Weapon::BOW>>();
+
+        // Crossbowman
+        buffs[SkillId::CROSSBOW_MASTERY] = std::make_unique<WeaponMasteryBuff<Weapon::CROSSBOW>>();
+
+        // Assassin
+        buffs[SkillId::CLAW_MASTERY] = std::make_unique<WeaponMasteryBuff<Weapon::CLAW>>();
+
+        // Bandit
+        buffs[SkillId::DAGGER_MASTERY] = std::make_unique<WeaponMasteryBuff<Weapon::DAGGER>>();
+
+        // Brawler
+        buffs[SkillId::KNUCKLER_MASTERY] = std::make_unique<WeaponMasteryBuff<Weapon::KNUCKLE>>();
+
+        // Gunslinger
+        buffs[SkillId::GUN_MASTERY] = std::make_unique<WeaponMasteryBuff<Weapon::GUN>>();
+
+        // Aran
+        buffs[SkillId::POLEARM_MASTERY_ARAN] = std::make_unique<WeaponMasteryBuff<Weapon::POLEARM>>();
+        buffs[SkillId::HIGH_MASTERY_ARAN] = std::make_unique<WeaponMasteryBuff<Weapon::POLEARM>>();
     }
 
     void PassiveBuffs::apply_buff(CharStats& stats, int32_t skill_id, int32_t skill_level) const

--- a/src/client/Character/SkillId.h
+++ b/src/client/Character/SkillId.h
@@ -151,6 +151,12 @@ namespace jrc
             // Priest
             PRIEST_TELEPORT = 2301001,
 
+            // Hunter
+            BOW_MASTERY = 3100000,
+
+            // Crossbowman
+            CROSSBOW_MASTERY = 3200000,
+
             // Hermit
             DRAIN = 4101005,
             AVENGER = 4111005,
@@ -163,6 +169,9 @@ namespace jrc
             DISORDER = 4001002,
             LUCKY_SEVEN = 4001344,
 
+            // Assassin
+            CLAW_MASTERY = 4100000,
+
             // Chief Bandit
             ASSAULTER = 4211002,
             BAND_OF_THIEVES = 4211004,
@@ -172,7 +181,18 @@ namespace jrc
             BOOMERANG_STEP = 4221007,
 
             // Bandit
-            MESO_EXPLOSION = 4211006
+            DAGGER_MASTERY = 4200000,
+            MESO_EXPLOSION = 4211006,
+
+            // Brawler
+            KNUCKLER_MASTERY = 5100001,
+
+            // Gunslinger
+            GUN_MASTERY = 5200000,
+
+            // Aran
+            POLEARM_MASTERY_ARAN = 21100000,
+            HIGH_MASTERY_ARAN = 21120001
         };
     }
 }


### PR DESCRIPTION
### Summary

This fixes the client-side minimum damage calculation so the lower bound updates correctly instead of behaving like it is derived mostly from the
secondary stat.

### Changes

- fix the minimum damage mastery floor for unmastered attacks
- convert WZ mastery values to the correct effective mastery percentages
- add missing weapon mastery passive mappings for affected jobs
- fix the Page sword mastery passive mapping
- align thief claw/dagger secondary stat handling with Cosmic's formula

### Result

Minimum damage in the stats UI now scales correctly with equipped stats, weapon setup, attack, and mastery instead of appearing stuck or under-calculated.