### PR TITLE
Prevent players and drops from getting stuck below the map

### DIFF
--- a/src/client/Gameplay/Physics/FootholdTree.cpp
+++ b/src/client/Gameplay/Physics/FootholdTree.cpp
@@ -19,9 +19,18 @@
 
 #include "../../Console.h"
 
+#include <algorithm>
 
 namespace jrc
 {
+    namespace
+    {
+        double clamp_to_foothold(const Foothold& foothold, double x)
+        {
+            return std::clamp(x, static_cast<double>(foothold.l()), static_cast<double>(foothold.r()));
+        }
+    }
+
     Footholdtree::Footholdtree(nl::node src)
     {
         int16_t leftw  =  30000;
@@ -199,6 +208,33 @@ namespace jrc
             phobj.fhid = get_fhid_below(x, y);
         }
 
+        if (phobj.fhid == 0 && y >= borders.second())
+        {
+            // Once an object falls below the last foothold, keep it recoverable by
+            // snapping it back to the closest point on the last known foothold.
+            if (curfh.id() != 0 && !curfh.is_wall())
+            {
+                double recovery_x = clamp_to_foothold(curfh, x);
+                double recovery_y = curfh.ground_below(recovery_x);
+                phobj.limitx(recovery_x);
+                phobj.limity(recovery_y);
+                phobj.fhid = curfh.id();
+                phobj.fhslope = curfh.slope();
+                phobj.onground = true;
+                phobj.enablejd = false;
+                phobj.groundbelow = recovery_y + 1.0;
+                phobj.fhlayer = curfh.layer();
+                return;
+            }
+
+            phobj.limity(borders.second());
+            phobj.fhslope = 0.0;
+            phobj.onground = true;
+            phobj.enablejd = false;
+            phobj.groundbelow = borders.second() + 1.0;
+            return;
+        }
+
         const Foothold& nextfh = get_fh(phobj.fhid);
         phobj.fhslope = nextfh.slope();
 
@@ -255,7 +291,6 @@ namespace jrc
         if (phobj.fhid == 0)
         {
             phobj.fhid = curfh.id();
-            phobj.limitx(curfh.x1());
         }
     }
 


### PR DESCRIPTION
### Summary

This fixes a client-side physics bug where entities can fall past the lowest foothold, get clamped to the map bottom border, and remain stuck in a falling
state.

### Root Cause

When an object falls below the last foothold, foothold lookup can return no valid foothold ID. In that case, physics clamps the object to the bottom
border, but the object does not recover to a grounded state.

### Changes

- add a bottom-of-map recovery path in `FootholdTree::update_fh()`
- snap objects back to the nearest valid point on the last known foothold when they fall past the lowest platform
- preserve grounded state and foothold layer after recovery
- remove the old fallback that forced `x` to `curfh.x1()` when foothold lookup failed

### Result

Objects using shared foothold physics no longer get stuck below the map after falling past the lowest platform.

### Affected Objects

- player characters
- dropped items
- physics-driven mobs