### PR TITLE
Align monster attack targeting with body center instead of head anchor

### DIFF
--- a/src/client/Gameplay/Combat/Combat.cpp
+++ b/src/client/Gameplay/Combat/Combat.cpp
@@ -60,7 +60,7 @@ namespace jrc
             int32_t target_oid = mb.damageeffect.target_oid;
             if (mobs.contains(target_oid))
             {
-                mb.target = mobs.get_mob_head_position(target_oid);
+                mb.target = mobs.get_mob_body_position(target_oid);
                 bool apply = mb.bullet.update(mb.target);
                 if (apply)
                 {
@@ -178,9 +178,9 @@ namespace jrc
 
     void Combat::apply_damage_effect(const DamageEffect& effect)
     {
-        Point<int16_t> head_position = mobs.get_mob_head_position(effect.target_oid);
+        Point<int16_t> body_position = mobs.get_mob_body_position(effect.target_oid);
         damagenumbers.push_back(effect.number);
-        damagenumbers.back().set_x(head_position.x());
+        damagenumbers.back().set_x(body_position.x());
 
         const SpecialMove& move = get_move(effect.move_id);
         mobs.apply_damage(effect.target_oid, effect.damage, effect.toleft, effect.user, move);
@@ -250,7 +250,7 @@ namespace jrc
                 if (mobs.contains(oid))
                 {
                     std::vector<DamageNumber> numbers = place_numbers(oid, line.second);
-                    Point<int16_t> head = mobs.get_mob_head_position(oid);
+                    Point<int16_t> target = mobs.get_mob_body_position(oid);
 
                     size_t i = 0;
                     for (auto& number : numbers)
@@ -272,7 +272,7 @@ namespace jrc
                             bullet_delay(i),
                             std::move(effect),
                             bullet,
-                            bullet_target(head, i, numbers.size())
+                            bullet_target(target, i, numbers.size())
                         );
                         i++;
                     }
@@ -339,15 +339,15 @@ namespace jrc
     std::vector<DamageNumber> Combat::place_numbers(int32_t oid, const std::vector<std::pair<int32_t, bool>>& damagelines)
     {
         std::vector<DamageNumber> numbers;
-        int16_t head = mobs.get_mob_head_position(oid).y();
+        int16_t body = mobs.get_mob_body_position(oid).y();
         for (auto& line : damagelines)
         {
             int32_t amount = line.first;
             bool critical = line.second;
             DamageNumber::Type type = critical ? DamageNumber::CRITICAL : DamageNumber::NORMAL;
-            numbers.emplace_back(type, amount, head);
+            numbers.emplace_back(type, amount, body);
 
-            head -= DamageNumber::rowheight(critical);
+            body -= DamageNumber::rowheight(critical);
         }
         return numbers;
     }

--- a/src/client/Gameplay/MapleMap/MapMobs.cpp
+++ b/src/client/Gameplay/MapleMap/MapMobs.cpp
@@ -174,7 +174,7 @@ namespace jrc
             if (mob && mob->is_alive() && mob->is_in_range(range))
             {
                 int32_t oid = mob->get_oid();
-                uint16_t distance = mob->get_position().distance(origin);
+                uint16_t distance = mob->get_body_position().distance(origin);
                 distances.emplace(distance, oid);
             }
         }
@@ -238,6 +238,18 @@ namespace jrc
         if (auto mob = mobs.get(oid))
         {
             return mob->get_position();
+        }
+        else
+        {
+            return {};
+        }
+    }
+
+    Point<int16_t> MapMobs::get_mob_body_position(int32_t oid) const
+    {
+        if (Optional<const Mob> mob = mobs.get(oid))
+        {
+            return mob->get_body_position();
         }
         else
         {

--- a/src/client/Gameplay/MapleMap/MapMobs.h
+++ b/src/client/Gameplay/MapleMap/MapMobs.h
@@ -64,6 +64,8 @@ namespace jrc
         MobAttack create_attack(int32_t oid) const;
         // Return the position of a mob.
         Point<int16_t> get_mob_position(int32_t oid) const;
+        // Return the body-center position used for combat targeting.
+        Point<int16_t> get_mob_body_position(int32_t oid) const;
         // Return the head position of a mob.
         Point<int16_t> get_mob_head_position(int32_t oid) const;
 
@@ -75,4 +77,3 @@ namespace jrc
         std::queue<MobSpawn> spawns;
     };
 }
-

--- a/src/client/Gameplay/MapleMap/Mob.cpp
+++ b/src/client/Gameplay/MapleMap/Mob.cpp
@@ -532,6 +532,41 @@ namespace jrc
         phobj.fhid = lastmove.fh;
     }
 
+    Rectangle<int16_t> Mob::get_bounds(Point<int16_t> position) const
+    {
+        Rectangle<int16_t> bounds = animations.at(stance).get_bounds();
+        if (flip && !noflip)
+        {
+            bounds = {
+                static_cast<int16_t>(-bounds.r()),
+                static_cast<int16_t>(-bounds.l()),
+                bounds.t(),
+                bounds.b()
+            };
+        }
+
+        bounds.shift(position);
+        return bounds;
+    }
+
+    Point<int16_t> Mob::get_body_position(Point<int16_t> position) const
+    {
+        // The NX "head" marker is appropriate for overhead UI, but combat
+        // impacts read better when they track the sprite's occupied bounds.
+        Rectangle<int16_t> bounds = get_bounds(position);
+        if (bounds.straight())
+        {
+            return get_head_position(position);
+        }
+
+        int32_t center_x = static_cast<int32_t>(bounds.l()) + bounds.r();
+        int32_t center_y = static_cast<int32_t>(bounds.t()) + bounds.b();
+        return {
+            static_cast<int16_t>(center_x / 2),
+            static_cast<int16_t>(center_y / 2)
+        };
+    }
+
     Point<int16_t> Mob::get_head_position(Point<int16_t> position) const
     {
         Point<int16_t> head = animations.at(stance).get_head();
@@ -602,7 +637,7 @@ namespace jrc
         switch (pos)
         {
         case 0:
-            shift = get_head_position({});
+            shift = get_body_position({});
             break;
         case 1:
             break;
@@ -773,6 +808,12 @@ namespace jrc
         Rectangle<int16_t> bounds = animations.at(stance).get_bounds();
         bounds.shift(get_position());
         return range.overlaps(bounds);
+    }
+
+    Point<int16_t> Mob::get_body_position() const
+    {
+        Point<int16_t> position = get_position();
+        return get_body_position(position);
     }
 
     Point<int16_t> Mob::get_head_position() const

--- a/src/client/Gameplay/MapleMap/Mob.h
+++ b/src/client/Gameplay/MapleMap/Mob.h
@@ -89,6 +89,8 @@ namespace jrc
         bool is_in_range(const Rectangle<int16_t>& range) const;
         /// Check if this mob is still alive.
         bool is_alive() const;
+        /// Return the body center used for combat targeting.
+        Point<int16_t> get_body_position() const;
         /// Return the head position.
         Point<int16_t> get_head_position() const;
 
@@ -126,6 +128,10 @@ namespace jrc
 
         /// Return the current 'head' position.
         Point<int16_t> get_head_position(Point<int16_t> position) const;
+        /// Return the current combat-targeting position.
+        Point<int16_t> get_body_position(Point<int16_t> position) const;
+        /// Return the current animation bounds in world space.
+        Rectangle<int16_t> get_bounds(Point<int16_t> position) const;
 
         std::map<Stance, Animation> animations;
         std::string name;


### PR DESCRIPTION
## Summary

This PR updates client-side monster targeting so combat interactions aim at the monster's body center rather than the NX head anchor.

Previously, attacks could feel like they were connecting at the top-middle of a mob sprite. This change makes projectile targeting, hit effects, and
damage-number placement track the monster's visual body area more naturally.

## Changes

- Added a body-center combat anchor for mobs based on current animation bounds
- Kept the existing head anchor behavior for overhead/UI-style usage
- Updated closest-target selection to use the mob body position
- Updated projectile homing to track the mob body position
- Updated hit-effect placement to use the body-centered combat anchor
- Updated damage-number placement to align with the body position

## Scope

This PR is intentionally limited to client-side combat targeting and impact presentation.

It does not change:

- Server behavior
- Asset data under `assets/`
- Mob collision / overlap semantics