### PR TITLE
Fix invisible world select screen for v83 WZ files

### DIFF
--- a/src/client/IO/UITypes/UIWorldSelect.cpp
+++ b/src/client/IO/UITypes/UIWorldSelect.cpp
@@ -31,47 +31,18 @@ namespace jrc
     UIWorldSelect::UIWorldSelect(std::vector<World> worlds, uint8_t worldcount)
         : UIElement({ 0, 0 }, { 800, 600 }) {
 
-        worldid = Setting<DefaultWorld>::get().load();
-        channelid = Setting<DefaultChannel>::get().load();
-
-        nl::node back = nl::nx::map["Back"]["login.img"]["back"];
-        nl::node worldsrc = nl::nx::ui["Login.img"]["WorldSelect"]["BtWorld"]["release"];
-        nl::node channelsrc = nl::nx::ui["Login.img"]["WorldSelect"]["BtChannel"];
-        nl::node frame = nl::nx::ui["Login.img"]["Common"]["frame"];
-
-        sprites.emplace_back(back["11"], Point<int16_t>(370, 300));
-        sprites.emplace_back(worldsrc["layer:bg"], Point<int16_t>(650, 45));
-        sprites.emplace_back(frame, Point<int16_t>(400, 290));
-
-        buttons[BT_ENTERWORLD] = std::make_unique<MapleButton>(
-            channelsrc["button:GoWorld"],
-            Point<int16_t>(200, 170)
-            );
+        worldid = 0;
+        channelid = 0;
 
         if (worldcount <= 0)
             return;
 
-        const World& world = worlds.front();
+        // Auto-select first world and channel, bypassing UI that requires
+        // post-Chaos UI.nx assets not present in v83 WZ files.
+        printf("[UIWorldSelect] Auto-selecting world %d channel %d\n", worldid, channelid);
 
-        buttons[BT_WORLD0] = std::make_unique<MapleButton>(worldsrc["button:15"], Point<int16_t>(650, 20));
-        buttons[BT_WORLD0]->set_state(Button::PRESSED);
-
-        sprites.emplace_back(channelsrc["layer:bg"], Point<int16_t>(200, 170));
-        sprites.emplace_back(channelsrc["release"]["layer:15"], Point<int16_t>(200, 170));
-
-        if (channelid >= world.channelcount)
-            channelid = 0;
-
-        for (uint8_t i = 0; i < world.channelcount; ++i)
-        {
-            nl::node chnode = channelsrc["button:" + std::to_string(i)];
-            buttons[BT_CHANNEL0 + i] = std::make_unique<TwoSpriteButton>(
-                chnode["normal"]["0"], chnode["keyFocused"]["0"],
-                Point<int16_t>(200, 170)
-                );
-            if (i == channelid)
-                buttons[BT_CHANNEL0 + i]->set_state(Button::PRESSED);
-        }
+        UI::get().disable();
+        CharlistRequestPacket(worldid, channelid).dispatch();
     }
 
     void UIWorldSelect::draw(float alpha) const

--- a/src/client/Net/Handlers/LoginHandlers.cpp
+++ b/src/client/Net/Handlers/LoginHandlers.cpp
@@ -102,12 +102,14 @@ namespace jrc
 
     void ServerlistHandler::handle(InPacket& recv) const
     {
+        printf("[ServerlistHandler] Received serverlist packet, available=%d\n", (int)recv.available());
         // Parse all worlds.
         std::vector<World> worlds;
         uint8_t worldcount = 0;
         while (recv.available())
         {
             World world = LoginParser::parse_world(recv);
+            printf("[ServerlistHandler] Parsed world wid=%d\n", world.wid);
             if (world.wid != -1)
             {
                 worlds.emplace_back(std::move(world));
@@ -116,9 +118,12 @@ namespace jrc
             else
             {
                 // "End of serverlist" packet.
+                printf("[ServerlistHandler] End of serverlist marker received\n");
                 return;
             }
         }
+
+        printf("[ServerlistHandler] Creating UIWorldSelect with %d worlds\n", worldcount);
 
         // Remove previous UIs.
         UI::get().remove(UIElement::LOGIN);
@@ -127,6 +132,7 @@ namespace jrc
         // Add the world selection screen to the ui.
         UI::get().emplace<UIWorldSelect>(worlds, worldcount);
         UI::get().enable();
+        printf("[ServerlistHandler] UIWorldSelect created\n");
     }
 
 


### PR DESCRIPTION
## Summary
- `UIWorldSelect` referenced post-Chaos `UI.nx` node paths absent from v83 WZ/NX files, leaving the screen black with no way to proceed after login
- Constructor now auto-selects world 0 / channel 0 and immediately dispatches `CharlistRequestPacket`, bypassing the broken UI
- Adds `printf` logging to `ServerlistHandler` to aid login flow debugging

## Test plan
- [ ] Log in with a v83 server — confirm client proceeds past world select to character select
- [ ] Check stdout for `[ServerlistHandler]` and `[UIWorldSelect]` log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)