### PR TITLE
Add getText dialog support for NPC conversations

### DIFF
--- a/src/client/IO/UITypes/UINpcTalk.cpp
+++ b/src/client/IO/UITypes/UINpcTalk.cpp
@@ -18,6 +18,7 @@
 #include "UINpcTalk.h"
 
 #include "../Components/MapleButton.h"
+#include "../UI.h"
 
 #include "../../Console.h"
 #include "../../Constants.h"
@@ -47,6 +48,8 @@ namespace jrc
         constexpr int16_t DIALOG_TEXT_Y_OFFSET = 16;
         constexpr int16_t OPTION_VERTICAL_GAP = 2;
         constexpr int16_t HOVER_UNDERLINE_THICKNESS = 1;
+        constexpr int16_t TEXTFIELD_BOTTOM_OFFSET = 30;
+        constexpr int16_t TEXTFIELD_HEIGHT = 20;
         constexpr int8_t SELECTION_DIALOGUE_TYPE = 4;
         constexpr int8_t LEGACY_SELECTION_DIALOGUE_TYPE = 5;
 
@@ -288,7 +291,7 @@ namespace jrc
         }
     }
 
-    UINpcTalk::UINpcTalk() : selected(0), hovered_selection(-1), scroll_offset(0), max_scroll(0)
+    UINpcTalk::UINpcTalk() : selected(0), hovered_selection(-1), scroll_offset(0), max_scroll(0), show_textfield(false)
     {
         nl::node src = nl::nx::ui["UIWindow2.img"]["UtilDlgEx"];
 
@@ -322,6 +325,18 @@ namespace jrc
         speaker.draw({ position + Point<int16_t>(80, 100), true });
         nametag.draw(position + Point<int16_t>(25, 100));
         name.draw(position + Point<int16_t>(80, 99));
+
+        if (show_textfield)
+        {
+            // Draw text input background box
+            int16_t box_x = static_cast<int16_t>(position.x() + DIALOG_TEXT_X);
+            int16_t box_y = static_cast<int16_t>(position.y() + top.height() + height - TEXTFIELD_BOTTOM_OFFSET);
+            int16_t box_w = TEXT_WIDTH;
+            int16_t box_h = TEXTFIELD_HEIGHT;
+            GraphicsGL::get().drawrectangle(box_x, box_y, box_w, box_h, 0.95f, 0.95f, 0.95f, 1.0f);
+            GraphicsGL::get().drawrectangle(box_x, static_cast<int16_t>(box_y + box_h - 1), box_w, 1, 0.4f, 0.4f, 0.4f, 1.0f);
+            textfield.draw(position);
+        }
 
         // Visible content bounds (relative to dialog position).
         int16_t content_top = static_cast<int16_t>(top.height() + TEXT_VERTICAL_PADDING);
@@ -391,12 +406,27 @@ namespace jrc
         return false;
     }
 
+    void UINpcTalk::submit_textfield()
+    {
+        std::string entered = textfield.get_text();
+        if (!entered.empty())
+        {
+            UI::get().remove_textfield();
+            NpcTalkMorePacket(type, entered).dispatch();
+            active = false;
+        }
+    }
+
     Button::State UINpcTalk::button_pressed(uint16_t buttonid)
     {
         switch (buttonid)
         {
         case OK:
-            if (is_selection_dialogue_type(type))
+            if (show_textfield)
+            {
+                submit_textfield();
+            }
+            else if (is_selection_dialogue_type(type))
             {
                 int32_t selection = selections.empty() ? 0 : selections[selected];
                 NpcTalkMorePacket(type, selection).dispatch();
@@ -454,6 +484,8 @@ namespace jrc
             }
             break;
         case END:
+            if (show_textfield)
+                UI::get().remove_textfield();
             NpcTalkMorePacket(type, end_confirms_dialogue ? 1 : 0).dispatch();
             active = false;
             break;
@@ -551,9 +583,24 @@ namespace jrc
             right_edge -= BUTTON_GAP;
         };
 
+        show_textfield = false;
+
         place_button(END, BUTTON_MARGIN);
         switch (msgtype)
         {
+        case 2:
+        {
+            // Text input dialog (sendGetText — server sends msgtype 2)
+            int16_t tf_y = static_cast<int16_t>(top.height() + height - TEXTFIELD_BOTTOM_OFFSET);
+            Rectangle<int16_t> tf_area(DIALOG_TEXT_X, DIALOG_TEXT_X + TEXT_WIDTH, tf_y, tf_y + TEXTFIELD_HEIGHT);
+            textfield = Textfield(Text::A12M, Text::LEFT, Text::BLACK, tf_area, 100);
+            textfield.set_enter_callback([this](std::string) {
+                submit_textfield();
+            });
+            show_textfield = true;
+            place_button_from_right(OK);
+            break;
+        }
         case 0:
         {
             // Text-only NPC dialogue carries the Prev/Next flags in two trailing
@@ -623,6 +670,22 @@ namespace jrc
             static_cast<int16_t>(Constants::viewheight() / 2 - dimension.y() / 2)
         };
 
+        // Focus textfield after all layout is finalized
+        if (show_textfield)
+        {
+            UI::get().focus_textfield(&textfield);
+        }
+
+    }
+
+    void UINpcTalk::update()
+    {
+        UIElement::update();
+
+        if (show_textfield)
+        {
+            textfield.update(position);
+        }
     }
 
     void UINpcTalk::send_key(int32_t, bool pressed, bool escape)
@@ -632,8 +695,13 @@ namespace jrc
             return;
         }
 
+        if (show_textfield)
+        {
+            UI::get().remove_textfield();
+        }
+
         active = false;
-        NpcTalkMorePacket(type, 0).dispatch();
+        NpcTalkMorePacket(type, static_cast<int8_t>(0)).dispatch();
     }
 
     void UINpcTalk::send_scroll(double yoffset)
@@ -650,6 +718,13 @@ namespace jrc
 
     UIElement::CursorResult UINpcTalk::send_cursor(bool clicked, Point<int16_t> cursorpos)
     {
+        if (show_textfield)
+        {
+            Cursor::State tstate = textfield.send_cursor(cursorpos - position, clicked);
+            if (tstate != Cursor::IDLE)
+                return { tstate, true };
+        }
+
         if (active && is_selection_dialogue_type(type) && !selection_labels.empty())
         {
             Point<int16_t> relative = cursorpos - position;

--- a/src/client/IO/UITypes/UINpcTalk.h
+++ b/src/client/IO/UITypes/UINpcTalk.h
@@ -17,6 +17,7 @@
 //////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include "../UIElement.h"
+#include "../Components/Textfield.h"
 
 #include "../../Graphics/Text.h"
 #include "../../Graphics/Texture.h"
@@ -35,6 +36,7 @@ namespace jrc
         UINpcTalk();
 
         void draw(float inter) const override;
+        void update() override;
         bool is_in_range(Point<int16_t> cursorpos) const override;
         void send_key(int32_t keycode, bool pressed, bool escape) override;
         void send_scroll(double yoffset) override;
@@ -55,6 +57,7 @@ namespace jrc
         int16_t get_dialogue_text_y() const;
         int16_t get_options_start_y() const;
         int32_t get_option_at(Point<int16_t> relative) const;
+        void submit_textfield();
 
         enum Buttons
         {
@@ -88,5 +91,8 @@ namespace jrc
         int32_t hovered_selection;
         int16_t scroll_offset;
         int16_t max_scroll;
+
+        Textfield textfield;
+        bool show_textfield;
     };
 }

--- a/src/client/Net/Handlers/NpcInteractionHandlers.cpp
+++ b/src/client/Net/Handlers/NpcInteractionHandlers.cpp
@@ -166,13 +166,21 @@ namespace jrc
         recv.skip(1);
 
         int32_t npcid = recv.read_int();
-        int8_t msgtype = recv.read_byte(); // 0 - textonly, 1 - yes/no, 4/5 - selection, 12 - accept/decline
+        int8_t msgtype = recv.read_byte(); // 0 - textonly, 1 - yes/no, 2 - getText, 4/5 - selection, 12 - accept/decline
         int8_t speaker = recv.read_byte();
         std::string text = recv.read_string();
 
         int16_t style = 0;
         if (msgtype == 0 && recv.length() > 0)
             style = recv.read_short();
+
+        // getText dialog (msgtype 2) has extra fields: default text, min/max
+        if (msgtype == 2 && recv.length() > 0)
+        {
+            recv.read_string(); // default text
+            if (recv.length() >= 4)
+                recv.read_int(); // min/max packed
+        }
 
         UI::get().emplace<UINpcTalk>();
         UI::get().enable();

--- a/src/client/Net/Packets/NpcInteractionPackets.h
+++ b/src/client/Net/Packets/NpcInteractionPackets.h
@@ -49,6 +49,12 @@ namespace jrc
             write_string(response);
         }
 
+        NpcTalkMorePacket(int8_t lastmsg, const std::string& text)
+            : NpcTalkMorePacket(lastmsg, static_cast<int8_t>(1))
+        {
+            write_string(text);
+        }
+
         NpcTalkMorePacket(int32_t selection) : NpcTalkMorePacket(4, 1)
         {
             write_int(selection);


### PR DESCRIPTION
## Summary
- Implements `sendGetText` NPC dialog (msgtype 2) with a textfield for player text input
- Parses the getText packet fields (default text, min/max) in `NpcDialogueHandler`
- Adds `NpcTalkMorePacket(int8_t, const std::string&)` constructor for text responses
- Handles textfield focus, rendering, cursor interaction, and cleanup on close/escape

## Test plan
- [x] Trigger an NPC that uses `sendGetText` (e.g. name input prompts) and verify the text input box appears
- [x] Type text and press Enter or click OK — verify the response is sent and dialog closes
- [x] Press Escape — verify the dialog closes and textfield is cleaned up
- [x] Click the close (END) button — verify same cleanup behavior
- [x] Verify other NPC dialog types (sendOk, sendYesNo, sendSimple) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)