### PR TITLE
FIX Background transparent objects flashing

### DIFF
--- a/src/client/Graphics/Animation.cpp
+++ b/src/client/Graphics/Animation.cpp
@@ -44,12 +44,12 @@ namespace jrc
         else if (hasa0)
         {
             uint8_t a0 = src["a0"];
-            opacities = { a0, 255 - a0 };
+            opacities = { a0, a0 };
         }
         else if (hasa1)
         {
             uint8_t a1 = src["a1"];
-            opacities = { 255 - a1, a1 };
+            opacities = { a1, a1 };
         }
         else
         {


### PR DESCRIPTION
Background transparent objects flashed when animations or parallax interacted with them, as per the gif example:

![Screen Recording 2026-04-08 at 22 30 59](https://github.com/user-attachments/assets/1d3cf644-3a65-4ba5-81b1-7069e0441da5)

This fixes this issue with all other trasparent assets, like temple of time auroras:

![2026-04-09 13-40-59](https://github.com/user-attachments/assets/35bce614-d56a-4576-984e-e53de899f969)

This issue's fix was made by mr.goose;
I got mr.goose permission to upload the fix and open the pull request.