### PR TITLE
Fix NPC dialog button handling across text and selection flows

### DIFF
--- a/src/client/IO/UITypes/UINpcTalk.cpp
+++ b/src/client/IO/UITypes/UINpcTalk.cpp
@@ -288,7 +288,17 @@ namespace jrc
         }
     }
 
-    UINpcTalk::UINpcTalk() : selected(0), hovered_selection(-1), scroll_offset(0), max_scroll(0)
+    UINpcTalk::UINpcTalk()
+        : height(0),
+          vtile(0),
+          dialogue_mode(DialogueMode::UNKNOWN),
+          slider(false),
+          type(0),
+          end_confirms_dialogue(false),
+          selected(0),
+          hovered_selection(-1),
+          scroll_offset(0),
+          max_scroll(0)
     {
         nl::node src = nl::nx::ui["UIWindow2.img"]["UtilDlgEx"];
 
@@ -305,7 +315,31 @@ namespace jrc
         buttons[NO] = std::make_unique<MapleButton>(src["BtNo"]);
 
         active = false;
-        end_confirms_dialogue = false;
+    }
+
+    UINpcTalk::DialogueMode UINpcTalk::resolve_dialogue_mode(int8_t msgtype, bool has_navigation_flags)
+    {
+        if (is_selection_dialogue_type(msgtype))
+        {
+            return DialogueMode::SELECTION;
+        }
+
+        switch (msgtype)
+        {
+        case 0:
+            return DialogueMode::TEXT;
+        case 1:
+            // Cosmic servers use type=1 for text dialogue with navigation flags,
+            // while some older variants used it for yes/no prompts.
+            return has_navigation_flags ? DialogueMode::TEXT : DialogueMode::YES_NO;
+        case 2:
+            return DialogueMode::YES_NO;
+        case 12:
+        case 14:
+            return DialogueMode::ACCEPT_DECLINE;
+        default:
+            return DialogueMode::UNKNOWN;
+        }
     }
 
     void UINpcTalk::draw(float inter) const
@@ -373,7 +407,7 @@ namespace jrc
         if (UIElement::is_in_range(cursorpos))
             return true;
 
-        if (active && is_selection_dialogue_type(type) && !selection_labels.empty())
+        if (active && dialogue_mode == DialogueMode::SELECTION && !selection_labels.empty())
         {
             Point<int16_t> relative = cursorpos - position;
             int16_t text_y = get_dialogue_text_y();
@@ -396,10 +430,10 @@ namespace jrc
         switch (buttonid)
         {
         case OK:
-            if (is_selection_dialogue_type(type))
+            if (dialogue_mode == DialogueMode::SELECTION)
             {
                 int32_t selection = selections.empty() ? 0 : selections[selected];
-                NpcTalkMorePacket(type, selection).dispatch();
+                NpcTalkMorePacket::selection(type, selection).dispatch();
                 active = false;
             }
             else
@@ -409,7 +443,7 @@ namespace jrc
             }
             break;
         case NEXT:
-            if (is_selection_dialogue_type(type))
+            if (dialogue_mode == DialogueMode::SELECTION)
             {
                 if (!selections.empty())
                 {
@@ -417,14 +451,14 @@ namespace jrc
                     refresh_selection_styles();
                 }
             }
-            else if (type == 0)
+            else if (dialogue_mode == DialogueMode::TEXT)
             {
                 NpcTalkMorePacket(type, 1).dispatch();
                 active = false;
             }
             break;
         case PREV:
-            if (is_selection_dialogue_type(type))
+            if (dialogue_mode == DialogueMode::SELECTION)
             {
                 if (!selections.empty())
                 {
@@ -433,37 +467,52 @@ namespace jrc
                     refresh_selection_styles();
                 }
             }
-            else if (type == 0)
+            else if (dialogue_mode == DialogueMode::TEXT)
             {
                 NpcTalkMorePacket(type, 0).dispatch();
                 active = false;
             }
             break;
         case YES:
-            if (type == 1 || type == 12)
+            if (dialogue_mode == DialogueMode::YES_NO || dialogue_mode == DialogueMode::ACCEPT_DECLINE)
             {
                 NpcTalkMorePacket(type, 1).dispatch();
                 active = false;
             }
             break;
         case NO:
-            if (type == 1 || type == 12)
+            if (dialogue_mode == DialogueMode::YES_NO || dialogue_mode == DialogueMode::ACCEPT_DECLINE)
             {
                 NpcTalkMorePacket(type, 0).dispatch();
                 active = false;
             }
             break;
         case END:
-            NpcTalkMorePacket(type, end_confirms_dialogue ? 1 : 0).dispatch();
+            if (end_confirms_dialogue)
+            {
+                NpcTalkMorePacket(type, 1).dispatch();
+            }
+            else
+            {
+                NpcTalkMorePacket::close(type).dispatch();
+            }
             active = false;
             break;
         }
         return Button::PRESSED;
     }
 
-    void UINpcTalk::change_text(int32_t npcid, int8_t msgtype, int16_t style, int8_t speakerbyte, const std::string& tx)
+    void UINpcTalk::change_text(
+        int32_t npcid,
+        int8_t msgtype,
+        int16_t style,
+        bool has_navigation_flags,
+        int8_t speakerbyte,
+        const std::string& tx
+    )
     {
         std::string processed_tx = replace_macros(tx);
+        dialogue_mode = resolve_dialogue_mode(msgtype, has_navigation_flags);
 
         selections.clear();
         selection_texts.clear();
@@ -472,7 +521,7 @@ namespace jrc
         hovered_selection = -1;
         end_confirms_dialogue = false;
 
-        if (is_selection_dialogue_type(msgtype))
+        if (dialogue_mode == DialogueMode::SELECTION)
         {
             parse_selections(processed_tx, prompttext);
             text = { Text::A12M, Text::LEFT, Text::DARKGREY, prompttext, TEXT_WIDTH, false };
@@ -552,14 +601,14 @@ namespace jrc
         };
 
         place_button(END, BUTTON_MARGIN);
-        switch (msgtype)
+        switch (dialogue_mode)
         {
-        case 0:
+        case DialogueMode::TEXT:
         {
             // Text-only NPC dialogue carries the Prev/Next flags in two trailing
-            // bytes. When both are absent the dialog expects a plain OK button.
-            bool has_prev = (style & 0x00FF) != 0;
-            bool has_next = (style & 0xFF00) != 0;
+            // bytes. When no flags are present the dialog expects a plain OK button.
+            bool has_prev = has_navigation_flags && (style & 0x00FF) != 0;
+            bool has_next = has_navigation_flags && (style & 0xFF00) != 0;
 
             if (has_next)
                 place_button_from_right(NEXT);
@@ -567,25 +616,21 @@ namespace jrc
                 place_button_from_right(PREV);
             if (!has_prev && !has_next)
             {
-                // Vanilla sendOk flow: in this case END should also confirm as a
-                // fallback, because some clients/UI skins fail to render BtOK.
-                end_confirms_dialogue = true;
                 place_button_from_right(OK);
             }
             break;
         }
-        case 1:
-        case 12:
+        case DialogueMode::YES_NO:
+        case DialogueMode::ACCEPT_DECLINE:
             place_button_from_right(NO);
             place_button_from_right(YES);
             break;
-        case SELECTION_DIALOGUE_TYPE:
-        case LEGACY_SELECTION_DIALOGUE_TYPE:
+        case DialogueMode::SELECTION:
             place_button_from_right(OK);
             place_button_from_right(NEXT);
             place_button_from_right(PREV);
             break;
-        default:
+        case DialogueMode::UNKNOWN:
             // Older scripts and some server variants use dialogue types that this
             // client does not model yet. Showing OK keeps the flow usable.
             place_button_from_right(OK);
@@ -598,7 +643,7 @@ namespace jrc
 
         // If text-only dialogue effectively has no visible action button besides
         // END, treat END as confirm to avoid trapping the player in mode=0 exits.
-        if (msgtype == 0 &&
+        if (dialogue_mode == DialogueMode::TEXT &&
             !has_visible_action_button(OK) &&
             !has_visible_action_button(NEXT) &&
             !has_visible_action_button(PREV))
@@ -608,7 +653,7 @@ namespace jrc
 
         // Same fallback for accept/decline prompts when YES/NO buttons fail
         // to render in some WZ/UI variants: END acts as accept so flow advances.
-        if ((msgtype == 1 || msgtype == 12) &&
+        if ((dialogue_mode == DialogueMode::YES_NO || dialogue_mode == DialogueMode::ACCEPT_DECLINE) &&
             !has_visible_action_button(YES) &&
             !has_visible_action_button(NO))
         {
@@ -633,7 +678,7 @@ namespace jrc
         }
 
         active = false;
-        NpcTalkMorePacket(type, 0).dispatch();
+        NpcTalkMorePacket::close(type).dispatch();
     }
 
     void UINpcTalk::send_scroll(double yoffset)
@@ -650,7 +695,7 @@ namespace jrc
 
     UIElement::CursorResult UINpcTalk::send_cursor(bool clicked, Point<int16_t> cursorpos)
     {
-        if (active && is_selection_dialogue_type(type) && !selection_labels.empty())
+        if (active && dialogue_mode == DialogueMode::SELECTION && !selection_labels.empty())
         {
             Point<int16_t> relative = cursorpos - position;
             int32_t hovered_option = get_option_at(relative);

--- a/src/client/IO/UITypes/UINpcTalk.h
+++ b/src/client/IO/UITypes/UINpcTalk.h
@@ -40,15 +40,32 @@ namespace jrc
         void send_scroll(double yoffset) override;
         CursorResult send_cursor(bool clicked, Point<int16_t> cursorpos) override;
 
-        void change_text(int32_t npcid, int8_t msgtype, int16_t style, int8_t speaker, const std::string& text);
+        void change_text(
+            int32_t npcid,
+            int8_t msgtype,
+            int16_t style,
+            bool has_navigation_flags,
+            int8_t speaker,
+            const std::string& text
+        );
 
     protected:
         Button::State button_pressed(uint16_t buttonid) override;
 
     private:
+        enum class DialogueMode
+        {
+            TEXT,
+            YES_NO,
+            ACCEPT_DECLINE,
+            SELECTION,
+            UNKNOWN
+        };
+
         void parse_selections(const std::string& text, std::string& rendered_text);
         static std::string strip_npc_tokens(const std::string& text);
         static std::string replace_macros(const std::string& source);
+        static DialogueMode resolve_dialogue_mode(int8_t msgtype, bool has_navigation_flags);
         void refresh_selection_styles();
         int16_t get_selection_text_height() const;
         int16_t get_dialogue_content_height() const;
@@ -76,6 +93,7 @@ namespace jrc
         Text name;
         int16_t height;
         int16_t vtile;
+        DialogueMode dialogue_mode;
         bool slider;
 
         int8_t type;

--- a/src/client/Net/Handlers/NpcInteractionHandlers.cpp
+++ b/src/client/Net/Handlers/NpcInteractionHandlers.cpp
@@ -166,19 +166,23 @@ namespace jrc
         recv.skip(1);
 
         int32_t npcid = recv.read_int();
-        int8_t msgtype = recv.read_byte(); // 0 - textonly, 1 - yes/no, 4/5 - selection, 12 - accept/decline
+        int8_t msgtype = recv.read_byte();
         int8_t speaker = recv.read_byte();
         std::string text = recv.read_string();
 
         int16_t style = 0;
-        if (msgtype == 0 && recv.length() > 0)
+        bool has_navigation_flags = false;
+        if ((msgtype == 0 || msgtype == 1) && recv.length() >= 2)
+        {
             style = recv.read_short();
+            has_navigation_flags = true;
+        }
 
         UI::get().emplace<UINpcTalk>();
         UI::get().enable();
 
         if (auto npctalk = UI::get().get_element<UINpcTalk>())
-            npctalk->change_text(npcid, msgtype, style, speaker, text);
+            npctalk->change_text(npcid, msgtype, style, has_navigation_flags, speaker, text);
     }
 
 

--- a/src/client/Net/Packets/NpcInteractionPackets.h
+++ b/src/client/Net/Packets/NpcInteractionPackets.h
@@ -54,10 +54,16 @@ namespace jrc
             write_int(selection);
         }
 
-        NpcTalkMorePacket(int8_t lastmsg, int32_t selection)
-            : NpcTalkMorePacket(lastmsg, static_cast<int8_t>(1))
+        static NpcTalkMorePacket selection(int8_t lastmsg, int32_t selection)
         {
-            write_int(selection);
+            NpcTalkMorePacket packet(lastmsg, static_cast<int8_t>(1));
+            packet.write_int(selection);
+            return packet;
+        }
+
+        static NpcTalkMorePacket close(int8_t lastmsg)
+        {
+            return NpcTalkMorePacket(lastmsg, static_cast<int8_t>(-1));
         }
     };
 


### PR DESCRIPTION
This PR fixes NPC dialog button behavior by resolving dialog handling from the actual packet shape instead of relying only on the raw message type.

## What Changed
- Added a `DialogueMode` layer in `UINpcTalk` to distinguish text, yes/no, accept/decline, selection, and unknown dialogs.
- Treated `msgtype=1` as text dialog when navigation flags are present, which matches Cosmic-style NPC flows.
- Updated button handling to use the resolved dialog mode for `OK`, `Prev`, `Next`, `Yes`, `No`, and `End`.
- Added explicit packet helpers for selection responses and dialog close responses.
- Updated the NPC interaction handler to read optional navigation flags for both `msgtype=0` and `msgtype=1`.

## Why
Some NPC dialogs were being interpreted incorrectly, which could cause the wrong buttons to render or send the wrong follow-up action. This change makes the client map dialog behavior more accurately to the server payload and keeps close/selection actions unambiguous.
